### PR TITLE
feature: add settings diagnostics e2e test

### DIFF
--- a/packages/e2e/src/json.settings-diagnostics.js
+++ b/packages/e2e/src/json.settings-diagnostics.js
@@ -1,0 +1,30 @@
+export const skip = true
+
+export const name = 'json.settings-diagnostics'
+
+export const test = async ({
+  FileSystem,
+  Workspace,
+  Main,
+  Settings,
+  Locator,
+  expect,
+}) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(
+    `${tmpDir}/settings.json`,
+    `{
+  "editor.fontSize": "invalid"
+}`,
+  )
+  await Workspace.setPath(tmpDir)
+  await Settings.update({ 'editor.diagnostics': true })
+
+  // act
+  await Main.openUri(`${tmpDir}/settings.json`)
+
+  // assert
+  const diagnosticError = Locator('.DiagnosticError')
+  await expect(diagnosticError).toBeVisible()
+}


### PR DESCRIPTION
Summary:
- add a skipped e2e regression test for diagnostics in settings.json
- verify an invalid editor setting renders an error squiggle