### PR TITLE
Add JSON schema completion and diagnostics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       ],
       "devDependencies": {
         "@lvce-editor/eslint-config": "^17.0.3",
-        "@lvce-editor/server": "0.70.27",
+        "@lvce-editor/server": "0.93.3",
         "@types/node": "^25.0.9",
         "eslint": "^10.7.0",
         "jest": "^30.2.0",
@@ -2921,67 +2921,25 @@
         "@lvce-editor/virtual-dom-worker": "^10.0.0"
       }
     },
-    "node_modules/@lvce-editor/api/node_modules/@lvce-editor/constants": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.19.0.tgz",
-      "integrity": "sha512-E+uV4TNbCXTjDqIyAoDC7HDBVlEXOLM1jCLXMmkT83m+TQr8tTehGY5nMfKSBBZI+DMe9NgUdA5NBJH43jXJOw==",
+    "node_modules/@lvce-editor/assert": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.7.0.tgz",
+      "integrity": "sha512-l9fHl7KDYAm4ou/B88fiRYVguA7z5Fx4lC8SmCLuCJFeXfjqPFh7rnGysToPNssmcPAEdwOgXvH+5U4v2V6q5Q==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@lvce-editor/api/node_modules/@lvce-editor/ipc": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.4.0.tgz",
-      "integrity": "sha512-CxMjWxF/NjoAwa2B5/hFzuXuPVSSTY2tM4khlLopXTqIHbkPJzo6FAAkBI8NRqabchRYCDDpvaO+IvASWwp+Zw==",
+    "node_modules/@lvce-editor/auth-process": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/auth-process/-/auth-process-1.10.0.tgz",
+      "integrity": "sha512-GlyU+4vJG88eSRsp9rjcj/ZDGRKR8oYKFAKB7pKA8ovSz9OlS14ddnqlaS5uZ6zpD2u5D6iS2eO78AeSvAaiBg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/verror": "^1.7.0",
-        "@lvce-editor/web-socket-server": "^2.1.0"
+      "bin": {
+        "auth-process": "bin/oauthProcess.js"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=24"
       }
-    },
-    "node_modules/@lvce-editor/api/node_modules/@lvce-editor/json-rpc": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.3.0.tgz",
-      "integrity": "sha512-P05TN3OvSVP0LkcG8xE79mGom/i89ttEJq3RfqRwv0sKvSi77NEp9JU3NGANNtBkbFuNWr8s6+XmSmhcj/3ahg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@lvce-editor/api/node_modules/@lvce-editor/rpc": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.8.0.tgz",
-      "integrity": "sha512-oazWvr0qLlBJCzHrRhMSziDU7k4poyj8ufyq+HKEb8gLtWqPCRBdSPtik3f8ORaCvZiv5IESLcFzlhJR/l4Ktw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/ipc": "^16.3.0",
-        "@lvce-editor/json-rpc": "^8.1.0",
-        "@lvce-editor/verror": "^1.7.0"
-      }
-    },
-    "node_modules/@lvce-editor/api/node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.36.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.36.0.tgz",
-      "integrity": "sha512-fbV4xYg0jZn06TcicEOm0wM+kA23OXZk+NK3QZsjNCIBdl0Pv6+V0GiR1aAbU+wlMmbLuHkEpmtSXfoBKrbGBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^5.19.0",
-        "@lvce-editor/rpc": "^6.4.0"
-      }
-    },
-    "node_modules/@lvce-editor/assert": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.5.1.tgz",
-      "integrity": "sha512-euS3PuVVjZy06bPFbgTz1yjQ0mY5BgWeYEDb9eQL2ncqYeap0ADy1D57nddlps1VkhHxj1g2ifXkLeIKLkQYJg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@lvce-editor/command": {
       "version": "2.0.0",
@@ -2991,16 +2949,16 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/constants": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-2.10.0.tgz",
-      "integrity": "sha512-JZ2hu1ZUaMQDsAi3b1E1CYzHsTlLaPO8htYzH5gvN11sLkUPyI51BlP3yZOOs9tlwJa0itN5Wy2utPyiy+NscQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.20.0.tgz",
+      "integrity": "sha512-yDtT/MF73BsyMpx7DQSoJJLM3hJKTII9TuGEguwJmgULxqV3mND86npuvOhKGUjTvL0Fs8BEQYFjO4DCrjncwA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-process": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.1.0.tgz",
-      "integrity": "sha512-HUyBfW/KvGcfgL+/H8H+c6ndC59mjpcnd9E8mutDzb+pI4issR1kNMeCA0qhKtMpBYTMZQwBJeBOk04quc2REg==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.10.0.tgz",
+      "integrity": "sha512-mEKsVl6i/Qd/YQuFvzr6806pg6YIq0vo9AQ1v42U7ir+7sD3y3fvUcEL7yyOrC2+CimeoByj8BTEHHMFJNuB2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3115,216 +3073,51 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.70.27",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.70.27.tgz",
-      "integrity": "sha512-jsUKw8hy6lGCB/RYWQaeNUEv518MZ8DX0P6/X98mSMg38gjHvDmOwzvHOXS0zWmHCmIMEdJMjlAPHHqBXEOxjw==",
+      "version": "0.93.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.93.3.tgz",
+      "integrity": "sha512-nP//ravlTi2Z+Ppza/1TjG4q1oQTxf5fU7CGYuXY7ZE19SAym/Hf4KXzc9PTwfteIhHbWyLTCG0A7yrsmSNWZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/rpc": "^5.4.0",
+        "@lvce-editor/assert": "^1.7.0",
+        "@lvce-editor/rpc": "^6.8.0",
         "@lvce-editor/verror": "^1.7.0",
         "execa": "^9.6.1",
-        "got": "^14.6.6",
+        "got": "^15.1.0",
         "minimist": "^1.2.8"
       },
       "engines": {
         "node": ">=24"
       }
     },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/execa": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "figures": "^6.1.0",
-        "get-stream": "^9.0.0",
-        "human-signals": "^8.0.1",
-        "is-plain-obj": "^4.1.0",
-        "is-stream": "^4.0.1",
-        "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.2.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.1.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.5.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/figures": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/human-signals": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/is-unicode-supported": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/npm-run-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/strip-final-newline": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@lvce-editor/file-system-process": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-4.1.0.tgz",
-      "integrity": "sha512-DOIS+zaqwip/D/EktLUjG2G1O5N2F7g5bi70n2A3cOE1HeJ/68zlDxTV5gGO+G7kU1XVQWfJZTLB+KqujvUi4Q==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.5.1.tgz",
+      "integrity": "sha512-kmVihRCa4LpcgwC4KN+jtdYuAAn+2UWfjtBaAZmuDLVqElQnn+lExWvjQoD3U2dOble9WU9/Y8uX5ejRI4mJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "trash": "^10.0.1",
-        "ws": "^8.19.0"
+        "trash": "^10.1.1",
+        "ws": "^8.21.0"
       },
       "bin": {
         "file-system-process": "bin/fileSystemProcess.js"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=24"
       }
     },
     "node_modules/@lvce-editor/file-watcher-process": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-3.6.0.tgz",
-      "integrity": "sha512-EqijIFxF8PoYWhnYpCjwueOz202vid4NpfX1KbW79hkVKOCTe7BlWg5z17K8BbEpP7F0VIUnpiy5mwOoMPoqMw==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.6.3.tgz",
+      "integrity": "sha512-Kjxgiv4HfJ3tDVicgfjzpBQLxZtUs4N5AjcSui3sl9pxvoW6kYhv13BakIaBXlvxpOsHSsbKITRwkCtmu0cJ+g==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@lvce-editor/assert": "^1.4.0",
-        "chokidar": "^4.0.3"
+        "@lvce-editor/assert": "^1.5.1",
+        "chokidar": "^5.0.0"
       },
       "bin": {
         "file-watcher-process": "bin/fileWatcherProcess.js"
@@ -3334,9 +3127,9 @@
       }
     },
     "node_modules/@lvce-editor/ipc": {
-      "version": "14.7.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-14.7.0.tgz",
-      "integrity": "sha512-O/bt6OHcDPBmhkxQNpqA08EoxI8fpEvtpzye5O4GowH08/BvTAsRVocmPFioDNAL1no40vDg0eYFHg0frh1daQ==",
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.4.0.tgz",
+      "integrity": "sha512-CxMjWxF/NjoAwa2B5/hFzuXuPVSSTY2tM4khlLopXTqIHbkPJzo6FAAkBI8NRqabchRYCDDpvaO+IvASWwp+Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3349,9 +3142,9 @@
       }
     },
     "node_modules/@lvce-editor/json-rpc": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-7.2.0.tgz",
-      "integrity": "sha512-zslYa6B7qzsvVCbSXp9XYDRlPiRVVdFzen1lhNtRbJ4mZxp8IZnbj+YmM8VA4SKnr7m8Ebo9OWwN28sPzjInjQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.3.0.tgz",
+      "integrity": "sha512-P05TN3OvSVP0LkcG8xE79mGom/i89ttEJq3RfqRwv0sKvSi77NEp9JU3NGANNtBkbFuNWr8s6+XmSmhcj/3ahg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3392,95 +3185,18 @@
         "open": "^10.1.2"
       }
     },
-    "node_modules/@lvce-editor/network-process/node_modules/array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
+    "node_modules/@lvce-editor/network-process/node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "dependencies": {
-        "array-uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/dir-glob": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
-      "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "path-type": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/execa": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "figures": "^6.1.0",
-        "get-stream": "^9.0.0",
-        "human-signals": "^8.0.1",
-        "is-plain-obj": "^4.1.0",
-        "is-stream": "^4.0.1",
-        "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.2.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.1.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.5.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/figures": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0"
-      },
       "engines": {
         "node": ">=18"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
     "node_modules/@lvce-editor/network-process/node_modules/glob": {
@@ -3525,15 +3241,32 @@
         "node": ">=4"
       }
     },
-    "node_modules/@lvce-editor/network-process/node_modules/human-signals": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+    "node_modules/@lvce-editor/network-process/node_modules/got": {
+      "version": "14.6.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-14.6.6.tgz",
+      "integrity": "sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==",
       "dev": true,
-      "license": "Apache-2.0",
+      "license": "MIT",
       "optional": true,
+      "dependencies": {
+        "@sindresorhus/is": "^7.0.1",
+        "byte-counter": "^0.1.0",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^13.0.12",
+        "decompress-response": "^10.0.0",
+        "form-data-encoder": "^4.0.2",
+        "http2-wrapper": "^2.2.1",
+        "keyv": "^5.5.3",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^4.0.1",
+        "responselike": "^4.0.2",
+        "type-fest": "^4.26.1"
+      },
       "engines": {
-        "node": ">=18.18.0"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
     "node_modules/@lvce-editor/network-process/node_modules/ignore": {
@@ -3544,74 +3277,18 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/@lvce-editor/network-process/node_modules/is-path-inside": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
-      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+    "node_modules/@lvce-editor/network-process/node_modules/lowercase-keys": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
-        "node": ">=12"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/is-unicode-supported": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@lvce-editor/network-process/node_modules/move-file": {
@@ -3626,24 +3303,6 @@
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/npm-run-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "path-key": "^4.0.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3669,34 +3328,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@lvce-editor/network-process/node_modules/p-map": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.5.tgz",
-      "integrity": "sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@lvce-editor/network-process/node_modules/pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -3708,20 +3339,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@lvce-editor/network-process/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@lvce-editor/network-process/node_modules/slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -3731,20 +3348,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/strip-final-newline": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@lvce-editor/network-process/node_modules/trash": {
@@ -3803,171 +3406,6 @@
         "tar-fs": "^3.1.0"
       }
     },
-    "node_modules/@lvce-editor/package-extension/node_modules/execa": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "figures": "^6.1.0",
-        "get-stream": "^9.0.0",
-        "human-signals": "^8.0.1",
-        "is-plain-obj": "^4.1.0",
-        "is-stream": "^4.0.1",
-        "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.2.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.1.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.5.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@lvce-editor/package-extension/node_modules/figures": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/package-extension/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/package-extension/node_modules/human-signals": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@lvce-editor/package-extension/node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/package-extension/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/package-extension/node_modules/is-unicode-supported": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/package-extension/node_modules/npm-run-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/package-extension/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/package-extension/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@lvce-editor/package-extension/node_modules/strip-final-newline": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@lvce-editor/preload": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/preload/-/preload-1.5.0.tgz",
@@ -4007,10 +3445,26 @@
         "node": ">=22"
       }
     },
+    "node_modules/@lvce-editor/process-explorer": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.10.0.tgz",
+      "integrity": "sha512-9IKLMpNiY/ta3b6grUT0GecULtRYXL3gkpxA99opt3IHeAWZYtgixqz4WUry0dBQhl9QQ6rd/rPFJut4IsJnLw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "process-explorer": "bin/processExplorer.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@vscode/windows-process-tree": "^0.8.0"
+      }
+    },
     "node_modules/@lvce-editor/pty-host": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-7.1.0.tgz",
-      "integrity": "sha512-xHutTrUVgCeLv4MWpxdgIRd52/QDLgCxMoGzyiUk7gGRhqZue/WtCTU1aAL0z37bGEy6jbEg7N9nQ8L9Geb2Jg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.3.0.tgz",
+      "integrity": "sha512-g2hTRb7lSc3uZaLq54dthlNG9ANG6eyJYPMih/WMqq+8GSoRblhbZZhsUpJdpaTb7hnwcsJ3y0LK5X8IKm2tDQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4018,544 +3472,80 @@
         "pty-host": "bin/ptyHost.js"
       },
       "optionalDependencies": {
-        "node-pty": "^1.1.0-beta34"
+        "node-pty": "1.1.0-beta34"
       }
     },
     "node_modules/@lvce-editor/ripgrep": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ripgrep/-/ripgrep-4.1.0.tgz",
-      "integrity": "sha512-J57lVXxRIbyuz1YwOi/hiUOMF6KDuOvht5OkhxVQOU971uv3j2t5bNdD6flq0hKmWESlr18p6sO0RTj8WMDIEA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ripgrep/-/ripgrep-5.3.0.tgz",
+      "integrity": "sha512-fuLxU+kKm3XJNQDlp9L8bfJKcB9BYwtrijy/zaoaK7iplGp8l6V/E54h4z0LfYaZX9Dhrr6ilhf/w+w3EzVOlw==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@lvce-editor/verror": "^1.7.0",
-        "execa": "^9.6.0",
-        "extract-zip": "^2.0.1",
-        "fs-extra": "^11.3.2",
-        "path-exists": "^5.0.0",
-        "tempy": "^3.1.0",
-        "xdg-basedir": "^5.1.0"
+        "@vscode/ripgrep": "1.18.0"
       },
       "engines": {
         "node": ">=22"
       }
     },
-    "node_modules/@lvce-editor/ripgrep/node_modules/crypto-random-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
-      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "type-fest": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/crypto-random-string/node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/execa": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "figures": "^6.1.0",
-        "get-stream": "^9.0.0",
-        "human-signals": "^8.0.1",
-        "is-plain-obj": "^4.1.0",
-        "is-stream": "^4.0.1",
-        "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.2.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.1.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.5.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/figures": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/human-signals": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/is-unicode-supported": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/npm-run-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "path-key": "^4.0.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/strip-final-newline": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/temp-dir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
-      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14.16"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/tempy": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.2.0.tgz",
-      "integrity": "sha512-d79HhZya5Djd7am0q+W4RTsSU+D/aJzM+4Y4AGJGuGlgM2L6sx5ZvOYTmZjqPhrDrV6xJTtRSm1JCLj6V6LHLQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-stream": "^3.0.0",
-        "temp-dir": "^3.0.0",
-        "type-fest": "^2.12.2",
-        "unique-string": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/tempy/node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/unique-string": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
-      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "crypto-random-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@lvce-editor/rpc": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-5.6.0.tgz",
-      "integrity": "sha512-9C/sXlcgTtdSPkmS2xhWaRTcV29HiRI25PY2Ujkp74DVEBJ9tVO2UKz4ZE0XhIAeXojQBJG1wrk2Jmhj7dSiXg==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.8.0.tgz",
+      "integrity": "sha512-oazWvr0qLlBJCzHrRhMSziDU7k4poyj8ufyq+HKEb8gLtWqPCRBdSPtik3f8ORaCvZiv5IESLcFzlhJR/l4Ktw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
         "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/ipc": "^14.7.0",
-        "@lvce-editor/json-rpc": "^7.2.0"
+        "@lvce-editor/ipc": "^16.3.0",
+        "@lvce-editor/json-rpc": "^8.1.0",
+        "@lvce-editor/verror": "^1.7.0"
       }
     },
     "node_modules/@lvce-editor/rpc-registry": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-7.5.0.tgz",
-      "integrity": "sha512-i9C7T4RP4MdtSt5Zj9E81l5/iu2oOiX5UzRmYKkwhgfirpaaTDJ6UFe8ou126CZfAM8g/5IAB2jqQpiLx4jwzA==",
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.36.0.tgz",
+      "integrity": "sha512-fbV4xYg0jZn06TcicEOm0wM+kA23OXZk+NK3QZsjNCIBdl0Pv6+V0GiR1aAbU+wlMmbLuHkEpmtSXfoBKrbGBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^2.8.0",
-        "@lvce-editor/rpc": "^5.2.0"
+        "@lvce-editor/constants": "^5.19.0",
+        "@lvce-editor/rpc": "^6.4.0"
       }
     },
     "node_modules/@lvce-editor/search-process": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-12.0.0.tgz",
-      "integrity": "sha512-svhY5/Y6ghdFynqa52ERZ4UDqzRGuZTtF1lVjpCgBpTTeB6+UCJbK0c7CE4Rt6stSJSKMKk+sKw0E3vcgUHwiw==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.1.0.tgz",
+      "integrity": "sha512-GlRDR+Mgy/ln2+J1UiYeAvTxkamnVAOXfsJwp6N4SpQllh1+3zKUjDduUIABakoIIP13Fk4InF0b9VQI/wvrew==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "execa": "^9.6.0",
-        "ws": "^8.18.3"
+        "@lvce-editor/constants": "^5.14.0",
+        "execa": "^9.6.1",
+        "ws": "^8.21.0"
       },
       "bin": {
         "search-process": "bin/searchProcess.js"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=24"
       },
       "optionalDependencies": {
-        "@lvce-editor/ripgrep": "^4.0.0"
-      }
-    },
-    "node_modules/@lvce-editor/search-process/node_modules/execa": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "figures": "^6.1.0",
-        "get-stream": "^9.0.0",
-        "human-signals": "^8.0.1",
-        "is-plain-obj": "^4.1.0",
-        "is-stream": "^4.0.1",
-        "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.2.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.1.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.5.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@lvce-editor/search-process/node_modules/figures": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/search-process/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/search-process/node_modules/human-signals": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@lvce-editor/search-process/node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/search-process/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/search-process/node_modules/is-unicode-supported": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/search-process/node_modules/npm-run-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "path-key": "^4.0.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/search-process/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/search-process/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@lvce-editor/search-process/node_modules/strip-final-newline": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "@lvce-editor/ripgrep": "^5.1.0"
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.70.27",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.70.27.tgz",
-      "integrity": "sha512-TVZ+eABAuoQE/502EON2YBd1ft0F2nutakHEyCSva/792OSSvzsPLGKvCuRHx5rKVAhVRLuxDvcEhaxf8XqFJg==",
+      "version": "0.93.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.93.3.tgz",
+      "integrity": "sha512-O1xmV+K23FQrEXjixD48AMrIGrObFnMxb+4R+ZqsS1y324x47MHsu0waP/9beIECct3IAtDzlYOiYMMtqliRcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.70.27",
-        "@lvce-editor/static-server": "0.70.27"
+        "@lvce-editor/shared-process": "0.93.3",
+        "@lvce-editor/static-server": "0.93.3"
       },
       "bin": {
         "server": "bin/server.js"
@@ -4565,46 +3555,49 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.70.27",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.70.27.tgz",
-      "integrity": "sha512-pKifbaf4RNGBtZldFHkzPwIP2RLuXFYLo+Us3SCVvOzKho6aATd9G59Kvv0PgvHXBnVc/RKJIoAKDfxTfSn1Cw==",
+      "version": "0.93.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.93.3.tgz",
+      "integrity": "sha512-K4n/g3Ng8JV0rY5nTb/w8+ME5mbQ3nu+XCQ5L65Q8aXl2vdDQ/HKTkOLwiZ0cWBSmx7vrqqLs+AFqresPXSdbg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/assert": "1.5.1",
-        "@lvce-editor/extension-host-helper-process": "0.70.27",
-        "@lvce-editor/ipc": "14.7.0",
-        "@lvce-editor/json-rpc": "7.2.0",
+        "@lvce-editor/assert": "1.7.0",
+        "@lvce-editor/auth-process": "1.10.0",
+        "@lvce-editor/extension-host-helper-process": "0.93.3",
+        "@lvce-editor/ipc": "16.4.0",
+        "@lvce-editor/json-rpc": "8.3.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
         "@lvce-editor/pretty-error": "2.0.0",
-        "@lvce-editor/rpc-registry": "7.5.0",
+        "@lvce-editor/process-explorer": "3.10.0",
+        "@lvce-editor/rpc-registry": "9.36.0",
         "@lvce-editor/verror": "1.7.0",
         "is-object": "^1.0.2",
+        "markdown-it": "^14.3.0",
         "xdg-basedir": "^5.1.0"
       },
       "engines": {
         "node": ">=24"
       },
       "optionalDependencies": {
-        "@lvce-editor/embeds-process": "4.1.0",
-        "@lvce-editor/file-system-process": "4.1.0",
-        "@lvce-editor/file-watcher-process": "3.6.0",
+        "@lvce-editor/embeds-process": "4.10.0",
+        "@lvce-editor/file-system-process": "5.5.1",
+        "@lvce-editor/file-watcher-process": "4.6.3",
         "@lvce-editor/network-process": "5.2.0",
         "@lvce-editor/preload": "1.5.0",
         "@lvce-editor/preview-process": "11.0.0",
-        "@lvce-editor/pty-host": "7.1.0",
-        "@lvce-editor/search-process": "12.0.0",
-        "@lvce-editor/typescript-compile-process": "4.1.0",
+        "@lvce-editor/pty-host": "8.3.0",
+        "@lvce-editor/search-process": "15.1.0",
+        "@lvce-editor/typescript-compile-process": "5.4.0",
         "open": "^11.0.0",
         "tail": "^2.2.6",
         "tmp-promise": "^3.0.3",
-        "trash": "^10.1.0"
+        "trash": "^10.1.1"
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.70.27",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.70.27.tgz",
-      "integrity": "sha512-I/aE0k9ZAb5n8m2Ys67a3KMLqIcONmotVI9fLkZyKe7sx0biauOAYvyAlBgPa38iSwELJQnbqwAmh9ds4PxZsw==",
+      "version": "0.93.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.93.3.tgz",
+      "integrity": "sha512-HarMnTSrLnybGyQy2AMiwC1cWtng1urQb86nOfKOmVeMm5nXQO6T72DHxBhQCSIqxB4g6pGc4b2zbjZSk5qTdA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4612,91 +3605,54 @@
       }
     },
     "node_modules/@lvce-editor/test-with-playwright": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright/-/test-with-playwright-2.25.0.tgz",
-      "integrity": "sha512-6WTbquHKZtaLbiKnLGgdpJnjRm8aMBJza49dGgYapOc0uEGTe573OZnT8DHIT2Ffx4lx4TEUAFXe1/fLZNV65w==",
+      "version": "22.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright/-/test-with-playwright-22.10.0.tgz",
+      "integrity": "sha512-TSa1MIZJvNk5I98YnFV3GxoQ5uEaKdveiPdkQjrSG+k/wFhXtfh5zOQj+eRlyliTJZTp66UxXfo8t80SrZzbEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/assert": "^1.4.0",
-        "@lvce-editor/command": "^1.2.0",
-        "@lvce-editor/ipc": "^14.3.0",
-        "@lvce-editor/json-rpc": "^6.2.0",
-        "@lvce-editor/test-with-playwright-worker": "2.25.0",
-        "@lvce-editor/verror": "^1.7.0",
-        "minimist": "^1.2.8"
+        "@lvce-editor/test-with-playwright-worker": "22.10.0",
+        "@lvce-editor/test-worker": "^17.5.0"
       },
       "bin": {
         "test-with-playwright": "bin/test-with-playwright.js"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@lvce-editor/test-with-playwright-worker": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright-worker/-/test-with-playwright-worker-2.25.0.tgz",
-      "integrity": "sha512-ef/kTt9LJ/aKwrw7lbRByUeCMVvpYdqBw6WvoncSs7lQWxRtXJbGWvMIEQ7LHky2H25TpUOMNAC2lK3U9oBhPw==",
+      "version": "22.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright-worker/-/test-with-playwright-worker-22.10.0.tgz",
+      "integrity": "sha512-4LWO0qXe+ZOh8FEn+8c5/7ZC7o3gMN4lOGbE5xHHldSF1kuTFcUgqkpViOgZDzjGt1Z3aB4ZrbK+pvDQpqsRRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/assert": "^1.4.0",
-        "@lvce-editor/command": "^1.2.0",
-        "@lvce-editor/ipc": "^14.3.0",
-        "@lvce-editor/json-rpc": "^6.2.0",
-        "@lvce-editor/verror": "^1.7.0",
-        "@playwright/test": "^1.53.2",
-        "get-port": "^7.1.0"
-      }
-    },
-    "node_modules/@lvce-editor/test-with-playwright-worker/node_modules/@lvce-editor/command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/command/-/command-1.2.0.tgz",
-      "integrity": "sha512-L9RCl+cOXyIlugI6od3uDqr4cGo0nVOfbgCTzYmR2WKKZE+iETf1A939b1Mv0WwiEiv42bSw7DJGHelaN6STKA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@lvce-editor/test-with-playwright-worker/node_modules/@lvce-editor/json-rpc": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-6.2.0.tgz",
-      "integrity": "sha512-8/iHluiEgfxHfQLzB0mj+cu6iMqIEZ/iCAPu12auzIPNII1FHE9VOINnV7m1odhDF32LHunOLGKcvjzQvQUaEA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@lvce-editor/test-with-playwright-worker/node_modules/get-port": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
-      "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
+        "@playwright/test": "1.61.1",
+        "get-port": "^7.2.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "v8-to-istanbul": "^9.3.0"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "engines": {
+        "node": ">=24"
       }
     },
-    "node_modules/@lvce-editor/test-with-playwright/node_modules/@lvce-editor/command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/command/-/command-1.2.0.tgz",
-      "integrity": "sha512-L9RCl+cOXyIlugI6od3uDqr4cGo0nVOfbgCTzYmR2WKKZE+iETf1A939b1Mv0WwiEiv42bSw7DJGHelaN6STKA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@lvce-editor/test-with-playwright/node_modules/@lvce-editor/json-rpc": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-6.2.0.tgz",
-      "integrity": "sha512-8/iHluiEgfxHfQLzB0mj+cu6iMqIEZ/iCAPu12auzIPNII1FHE9VOINnV7m1odhDF32LHunOLGKcvjzQvQUaEA==",
+    "node_modules/@lvce-editor/test-worker": {
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-worker/-/test-worker-17.5.0.tgz",
+      "integrity": "sha512-TM4uisYLRVQdktjZ4LZsGcmd8bel/bUlNYrh063Po3VG6PYj5+81IAUT3NjQmuJp38Y2VO5g0GPY/EygNAY/jQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/typescript-compile-process": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-4.1.0.tgz",
-      "integrity": "sha512-tpWzwetxgvKCwNROOf89mqH6Hl4n1muvMQS55i75/t6JnntUTfMyVCMjf30jxe2+cZWjkHTLU7Wu7b2smzSyDw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.4.0.tgz",
+      "integrity": "sha512-nBHfHtqiWTMDJpdsq3xju/RdL8LLH/rsUzcda0y0wbSlmG0PmCOvNIN3LA+FfLX+FpHtDk41JRc7TGZ0vW971Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "dependencies": {
-        "ws": "^8.18.3"
-      },
       "bin": {
         "typescript-compile-process": "bin/typescriptCompileProcess.js"
       },
@@ -4720,13 +3676,6 @@
       "dependencies": {
         "@lvce-editor/constants": "^5.14.0"
       }
-    },
-    "node_modules/@lvce-editor/virtual-dom-worker/node_modules/@lvce-editor/constants": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.19.0.tgz",
-      "integrity": "sha512-E+uV4TNbCXTjDqIyAoDC7HDBVlEXOLM1jCLXMmkT83m+TQr8tTehGY5nMfKSBBZI+DMe9NgUdA5NBJH43jXJOw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@lvce-editor/web-socket-server": {
       "version": "2.1.0",
@@ -5394,25 +4343,14 @@
         "node": ">=8"
       }
     },
-    "node_modules/@sindresorhus/df/node_modules/p-finally": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@sindresorhus/is": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
-      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-8.1.0.tgz",
+      "integrity": "sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
@@ -5653,17 +4591,6 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.63.0",
@@ -6251,6 +5178,208 @@
         "win32"
       ]
     },
+    "node_modules/@vscode/ripgrep": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.18.0.tgz",
+      "integrity": "sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "optionalDependencies": {
+        "@vscode/ripgrep-darwin-arm64": "1.18.0",
+        "@vscode/ripgrep-darwin-x64": "1.18.0",
+        "@vscode/ripgrep-linux-arm": "1.18.0",
+        "@vscode/ripgrep-linux-arm64": "1.18.0",
+        "@vscode/ripgrep-linux-ia32": "1.18.0",
+        "@vscode/ripgrep-linux-ppc64": "1.18.0",
+        "@vscode/ripgrep-linux-riscv64": "1.18.0",
+        "@vscode/ripgrep-linux-s390x": "1.18.0",
+        "@vscode/ripgrep-linux-x64": "1.18.0",
+        "@vscode/ripgrep-win32-arm64": "1.18.0",
+        "@vscode/ripgrep-win32-ia32": "1.18.0",
+        "@vscode/ripgrep-win32-x64": "1.18.0"
+      }
+    },
+    "node_modules/@vscode/ripgrep-darwin-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-arm64/-/ripgrep-darwin-arm64-1.18.0.tgz",
+      "integrity": "sha512-r3ktHSvbFycQNF6sl7sNDPocpsI7J+mEzh1IaZFkY0spm3k2Z9t8hPAeOK7+p0l6p6/swkQC14XWX01low+94Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-darwin-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-x64/-/ripgrep-darwin-x64-1.18.0.tgz",
+      "integrity": "sha512-25b4gWbL138dGuQU244ebCKKc0q05ULBMoFSz9oAEUHNeqK/lOJViDS7DRvbDazzAzSEdan391Znks/R5mkaTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-arm": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm/-/ripgrep-linux-arm-1.18.0.tgz",
+      "integrity": "sha512-GDAvufNDHu8zqLEmXstalQF0Wh6wQvdsBi/Vg3Yi3CK4a8XoFXqqXVEHEZ9xQz3t0NfoSEc9JbvK9DDS6FxyxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm64/-/ripgrep-linux-arm64-1.18.0.tgz",
+      "integrity": "sha512-lQ/5zTG++U0E3IhVgS4EPTTn/U4okncaRMM5GOFfOYZywS4nuD31GhkHbNYlDk5CuDC68+hYJ0/eQeyCKJDA+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ia32/-/ripgrep-linux-ia32-1.18.0.tgz",
+      "integrity": "sha512-YWLkSUtFd4Jh5EepIhA9RJSfv3uMAVMo+2rBIGHPBnvgLrZciIs2cDKei1/p6Wc/aCzUoHyMAg2R6tw4ZCBKGg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ppc64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ppc64/-/ripgrep-linux-ppc64-1.18.0.tgz",
+      "integrity": "sha512-quXVY8fwQ8O/lvU1yrSqSl3jlUzysRSb+AfUfCL/tRtphxsKlFvPAejryZ6vg4Bgvn8XL74xb4qMCDmWgYrT5w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-riscv64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-riscv64/-/ripgrep-linux-riscv64-1.18.0.tgz",
+      "integrity": "sha512-f5kBQBrWfQt8Q7OhSORuNDei5dkYagBj3y4jImSUXGMy8B/Ke7SltSRcUtjPv166FAFfHCAmWuZp3+cWnX2/Vw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-s390x": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-s390x/-/ripgrep-linux-s390x-1.18.0.tgz",
+      "integrity": "sha512-rTOcJFGGcl2c07RUOWUo4U1ndnemKhY6A9hnMB18uk7jSgJc0d/QLBGWMWpumdtoJtpizn/wIv5mXIisJukusQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-x64/-/ripgrep-linux-x64-1.18.0.tgz",
+      "integrity": "sha512-mQ3bVrUpnD2vs7QT0vX90Lt0cnUq467uFtEktIdsJJmW296RoSULRGqWgzG1AKxyBpNDD6l4ZO4qKf6SgyC23Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-arm64/-/ripgrep-win32-arm64-1.18.0.tgz",
+      "integrity": "sha512-vfTIjq1OHnzUjxZcHVQAMbnggp8dpGf+0QKFOZHwWPqFwXxQC8eCWM+5NUdoJ6yrElCeMzoUTXoK/LdZaniB+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-ia32/-/ripgrep-win32-ia32-1.18.0.tgz",
+      "integrity": "sha512-//rfAE+BOw5AC2EMmepmiE36jUuevtQYNQqqlw1s3m9FlRxjxEut97RkRPHAu9BG4mSojatZx+kXZXNdyI9caQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-x64/-/ripgrep-win32-x64-1.18.0.tgz",
+      "integrity": "sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/windows-process-tree": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@vscode/windows-process-tree/-/windows-process-tree-0.8.0.tgz",
+      "integrity": "sha512-TI+h2GRwX+igD/YYJMQQVAFcsCNSg7Te2yYxQpKMzwto5RsJ8d2KKgOeur/p/6sAOQwZvopiTDOClyTHEn9MhQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "7.1.0"
+      }
+    },
     "node_modules/@zkochan/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@zkochan/rimraf/-/rimraf-3.0.2.tgz",
@@ -6384,12 +5513,33 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/array-timsort": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
       "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "array-uniq": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/array-uniq": {
       "version": "1.0.3",
@@ -6733,17 +5883,6 @@
         "node-int64": "^0.4.0"
       }
     },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -6952,20 +6091,33 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/chunk-data": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chunk-data/-/chunk-data-0.1.0.tgz",
+      "integrity": "sha512-zFyPtyC0SZ6Zu79b9sOYtXZcgrsXe0RpePrzRyj52hYVFG1+Rk6rBqjjOEk+GNQwc3PIX+86teQMok970pod1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/chunkify": {
@@ -7455,6 +6607,45 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/dir-glob": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+      "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "path-type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/dir-glob/node_modules/path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/dir-glob/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/e2e": {
       "resolved": "packages/e2e",
       "link": true
@@ -7525,6 +6716,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -8281,6 +7485,129 @@
         "bare-events": "^2.7.0"
       }
     },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/execa/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/execa/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/exit-x": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
@@ -8307,45 +7634,6 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/extract-zip/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -8453,17 +7741,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -8480,6 +7757,22 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-entry-cache": {
@@ -8615,6 +7908,7 @@
       "integrity": "sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 18"
       }
@@ -8629,9 +7923,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -8734,6 +8028,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-port": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
+      "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-stream": {
@@ -8878,6 +8185,67 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globby": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.3",
+        "path-type": "^6.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/globby/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/globrex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
@@ -8886,30 +8254,46 @@
       "license": "MIT"
     },
     "node_modules/got": {
-      "version": "14.6.6",
-      "resolved": "https://registry.npmjs.org/got/-/got-14.6.6.tgz",
-      "integrity": "sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-15.1.0.tgz",
+      "integrity": "sha512-DG+DAAkRtno+oDr/GBsliAkhN9+zczOPM5qXk3efDZY3qvyRnZU+NwQlb/IOY6cSnxxTR9z3aHCcShJyjb0hJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sindresorhus/is": "^7.0.1",
+        "@sindresorhus/is": "^8.0.0",
         "byte-counter": "^0.1.0",
         "cacheable-lookup": "^7.0.0",
-        "cacheable-request": "^13.0.12",
+        "cacheable-request": "^13.0.18",
+        "chunk-data": "^0.1.0",
         "decompress-response": "^10.0.0",
-        "form-data-encoder": "^4.0.2",
         "http2-wrapper": "^2.2.1",
-        "keyv": "^5.5.3",
-        "lowercase-keys": "^3.0.0",
-        "p-cancelable": "^4.0.1",
+        "keyv": "^5.6.0",
+        "lowercase-keys": "^4.0.1",
         "responselike": "^4.0.2",
-        "type-fest": "^4.26.1"
+        "type-fest": "^5.6.0",
+        "uint8array-extras": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/got/node_modules/type-fest": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
       },
       "engines": {
         "node": ">=20"
       },
       "funding": {
-        "url": "https://github.com/sindresorhus/got?sponsor=1"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/graceful-fs": {
@@ -9278,6 +8662,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-safe-filename": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-safe-filename/-/is-safe-filename-0.1.1.tgz",
@@ -9299,6 +8710,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-windows": {
@@ -10629,10 +10053,16 @@
         "url": "https://github.com/sponsors/ota-meshi"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
+    },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -10718,6 +10148,26 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -10760,13 +10210,13 @@
       }
     },
     "node_modules/lowercase-keys": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-4.0.1.tgz",
+      "integrity": "sha512-wI9Nui/L8VfADa/cr/7NQruaASk1k23/Uh1khQ02BCVYiiy8F4AhOGnQzJy3Fl/c44GnYSbZHv8g7EcG3kJ1Qg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10828,6 +10278,34 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
       }
     },
     "node_modules/markdown-table": {
@@ -11112,6 +10590,13 @@
       "integrity": "sha512-U9w+PzSZ00Z5m9rZ5ARVFL5xOfuCHdKYi/1RRwDCJsboFgJDNT3zT6PIPD7mZQYaQLhsZM3GfDRgSMRHhSmVng==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -11809,6 +11294,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -11856,17 +11354,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@sindresorhus/df/-/df-1.0.1.tgz",
       "integrity": "sha512-1Hyp7NQnD/u4DSxR2DGW78TF9k7R0wZ8ev0BpMAIzA6yTQSHqNb5wTuvtcPYf4FWbVse2rW7RgDsyL8ua2vXHw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/mount-point/node_modules/pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -11936,12 +11423,15 @@
       "license": "MIT"
     },
     "node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
+      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "engines": {
+        "node": "^16 || ^18 || >= 20"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -11951,9 +11441,9 @@
       "license": "MIT"
     },
     "node_modules/node-pty": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
-      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "version": "1.1.0-beta34",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0-beta34.tgz",
+      "integrity": "sha512-RraDtX9RS1G1I5iO7e4YIOIA4arzd4ZVCD4mZr7+szaNupoTg9fxDCRr0EanqS0Qlzgm3PIdHNbPmblJguJuyg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -12091,6 +11581,7 @@
       "integrity": "sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=14.16"
       }
@@ -12124,6 +11615,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-finally": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -12151,6 +11653,20 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
+      "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -12350,37 +11866,18 @@
       }
     },
     "node_modules/path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "dependencies": {
-        "pify": "^3.0.0"
+      "engines": {
+        "node": ">=18"
       },
-      "engines": {
-        "node": ">=4"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/path-type/node_modules/pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -12400,6 +11897,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/pinkie": {
@@ -12650,6 +12158,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
@@ -12723,14 +12241,14 @@
       "license": "MIT"
     },
     "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",
@@ -12790,22 +12308,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/rename-overwrite/node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/require-directory": {
@@ -12903,6 +12405,19 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/responselike/node_modules/lowercase-keys": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -13135,19 +12650,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/sort-package-json/node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -13462,6 +12964,19 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tail": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/tail/-/tail-2.2.6.tgz",
@@ -13562,19 +13077,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/text-decoder": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
@@ -13602,9 +13104,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -13668,95 +13170,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/trash/node_modules/@sindresorhus/merge-streams": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/trash/node_modules/globby": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
-      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^2.1.0",
-        "fast-glob": "^3.3.3",
-        "ignore": "^7.0.3",
-        "path-type": "^6.0.0",
-        "slash": "^5.1.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/trash/node_modules/ignore": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/trash/node_modules/is-path-inside": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
-      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/trash/node_modules/p-map": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.5.tgz",
-      "integrity": "sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/trash/node_modules/path-type": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
-      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/trash/node_modules/powershell-utils": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.0.tgz",
@@ -13766,20 +13179,6 @@
       "optional": true,
       "engines": {
         "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/trash/node_modules/slash": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -13965,6 +13364,13 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/uglify-js": {
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
@@ -13977,6 +13383,19 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/undici-types": {
@@ -14472,18 +13891,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -14530,181 +13937,19 @@
         "execa": "^9.5.2"
       }
     },
-    "packages/build/node_modules/execa": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "figures": "^6.1.0",
-        "get-stream": "^9.0.0",
-        "human-signals": "^8.0.1",
-        "is-plain-obj": "^4.1.0",
-        "is-stream": "^4.0.1",
-        "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.2.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.1.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.5.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "packages/build/node_modules/figures": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/build/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/build/node_modules/human-signals": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
-    "packages/build/node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/build/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/build/node_modules/is-unicode-supported": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/build/node_modules/npm-run-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/build/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/build/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/build/node_modules/strip-final-newline": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "packages/e2e": {
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@lvce-editor/test-with-playwright": "^2.11.0"
+        "@lvce-editor/test-with-playwright": "^22.10.0"
       }
     },
     "packages/extension": {
       "name": "builtin.language-features-json",
       "version": "0.0.0-dev",
+      "dependencies": {
+        "jsonc-parser": "^3.3.1"
+      },
       "devDependencies": {
         "@lvce-editor/api": "^8.53.1"
       }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "type": "module",
   "devDependencies": {
     "@lvce-editor/eslint-config": "^17.0.3",
-    "@lvce-editor/server": "0.70.27",
+    "@lvce-editor/server": "0.93.3",
     "@types/node": "^25.0.9",
     "eslint": "^10.7.0",
     "jest": "^30.2.0",

--- a/packages/build/src/build-extension.js
+++ b/packages/build/src/build-extension.js
@@ -7,6 +7,9 @@ const extension = path.join(root, 'packages', 'extension')
 const entryPoint = path.join(extension, 'src', 'languageFeaturesJsonMain.ts')
 const outdir = path.join(extension, 'dist')
 const outfile = path.join(outdir, 'languageFeaturesJsonMain.js')
+const jsonSchemaContributions = process.env.JSON_SCHEMA_CONTRIBUTIONS || '[]'
+const assetPathPrefix = process.env.ASSET_PATH_PREFIX || '../../'
+const loadBuiltInJsonSchemas = process.env.LOAD_BUILT_IN_JSON_SCHEMAS || 'true'
 
 fs.rmSync(outdir, { recursive: true, force: true })
 fs.mkdirSync(outdir, { recursive: true })
@@ -14,7 +17,9 @@ fs.mkdirSync(outdir, { recursive: true })
 await esbuild.build({
   bundle: true,
   define: {
-    ASSET_PATH_PREFIX: JSON.stringify('../../'),
+    ASSET_PATH_PREFIX: JSON.stringify(assetPathPrefix),
+    JSON_SCHEMA_CONTRIBUTIONS: jsonSchemaContributions,
+    LOAD_BUILT_IN_JSON_SCHEMAS: loadBuiltInJsonSchemas,
   },
   entryPoints: [entryPoint],
   external: ['electron', 'node:*'],

--- a/packages/e2e/fixtures/prettier-schema/extension.json
+++ b/packages/e2e/fixtures/prettier-schema/extension.json
@@ -1,0 +1,13 @@
+{
+  "id": "test.prettier-schema",
+  "name": "Prettier Schema Fixture",
+  "description": "Contributes package.json validation for e2e tests",
+  "version": "0.0.0",
+  "browser": "src/extensionMain.js",
+  "jsonValidation": [
+    {
+      "fileMatch": "package.json",
+      "url": "./schemas/package.schema.json"
+    }
+  ]
+}

--- a/packages/e2e/fixtures/prettier-schema/schemas/package.schema.json
+++ b/packages/e2e/fixtures/prettier-schema/schemas/package.schema.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "prettier": {
+      "type": "object",
+      "properties": {
+        "semi": {
+          "type": "boolean"
+        },
+        "printWidth": {
+          "type": "integer"
+        },
+        "trailingComma": {
+          "type": "string",
+          "enum": ["all", "es5", "none"]
+        }
+      }
+    }
+  }
+}

--- a/packages/e2e/fixtures/prettier-schema/src/extensionMain.js
+++ b/packages/e2e/fixtures/prettier-schema/src/extensionMain.js
@@ -1,0 +1,1 @@
+export const activate = () => {}

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -4,15 +4,15 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build:extension": "node ../build/src/build-extension.js",
-    "e2e": "npm run build:extension && test-with-playwright --only-extension=../extension --test-path=.",
-    "e2e:headless": "npm run build:extension && test-with-playwright --only-extension=../extension --test-path=. --headless"
+    "build:extension": "node scripts/build-extension.js && node scripts/prepare-extension.js",
+    "e2e": "npm run build:extension && test-with-playwright --only-extension=.tmp/extension --test-path=.",
+    "e2e:headless": "npm run build:extension && test-with-playwright --only-extension=.tmp/extension --test-path=. --headless"
   },
   "type": "module",
   "keywords": [],
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@lvce-editor/test-with-playwright": "^2.11.0"
+    "@lvce-editor/test-with-playwright": "^22.10.0"
   }
 }

--- a/packages/e2e/scripts/build-extension.js
+++ b/packages/e2e/scripts/build-extension.js
@@ -1,0 +1,29 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const root = join(import.meta.dirname, '..', '..', '..')
+const schema = await readFile(
+  join(
+    root,
+    'packages',
+    'e2e',
+    'fixtures',
+    'prettier-schema',
+    'schemas',
+    'package.schema.json',
+  ),
+  'utf8',
+)
+
+process.env.JSON_SCHEMA_CONTRIBUTIONS = JSON.stringify([
+  {
+    fileMatch: 'package.json',
+    schema: JSON.parse(schema),
+    url: 'inline:e2e',
+  },
+])
+process.env.ASSET_PATH_PREFIX = '../'
+process.env.LOAD_BUILT_IN_JSON_SCHEMAS = 'false'
+
+await import(pathToFileURL(join(root, 'packages', 'build', 'src', 'build-extension.js')).href)

--- a/packages/e2e/scripts/prepare-extension.js
+++ b/packages/e2e/scripts/prepare-extension.js
@@ -1,0 +1,18 @@
+import { cp, mkdir, rm } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+const source = join(root, 'packages', 'extension')
+const target = join(root, 'packages', 'e2e', '.tmp', 'extension')
+
+await rm(target, { force: true, recursive: true })
+await cp(source, target, { recursive: true })
+await mkdir(join(target, 'schemas'), { recursive: true })
+await cp(join(root, 'packages', 'schemas', 'src'), join(target, 'schemas', 'src'), {
+  recursive: true,
+})
+await cp(
+  join(root, 'packages', 'e2e', 'fixtures', 'prettier-schema', 'schemas', 'package.schema.json'),
+  join(target, 'schemas', 'prettier-package.schema.json'),
+)

--- a/packages/e2e/src/json.package-json-prettier-boolean-diagnostic.js
+++ b/packages/e2e/src/json.package-json-prettier-boolean-diagnostic.js
@@ -1,0 +1,35 @@
+export const skip = true
+
+export const name = 'json.package-json-prettier-boolean-diagnostic'
+
+export const test = async ({
+  Editor,
+  FileSystem,
+  Main,
+  Settings,
+  Workspace,
+}) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/package.json`
+  await FileSystem.writeFile(
+    uri,
+    '{\n  "prettier": {\n    "semi": "yes"\n  }\n}',
+  )
+  await Workspace.setPath(tmpDir)
+  await Settings.update({ 'editor.diagnostics': true })
+  await Main.openUri(uri)
+
+  await Editor.shouldHaveDiagnostics([
+    {
+      code: 'type',
+      columnIndex: 12,
+      endColumnIndex: 17,
+      endRowIndex: 2,
+      message: 'Incorrect type. Expected "boolean" but received "string".',
+      rowIndex: 2,
+      source: 'json',
+      type: 'error',
+      uri,
+    },
+  ])
+}

--- a/packages/e2e/src/json.package-json-prettier-enum-completion.js
+++ b/packages/e2e/src/json.package-json-prettier-enum-completion.js
@@ -1,0 +1,28 @@
+export const skip = true
+
+export const name = 'json.package-json-prettier-enum-completion'
+
+export const test = async ({
+  Editor,
+  expect,
+  FileSystem,
+  Locator,
+  Main,
+  Workspace,
+}) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(
+    `${tmpDir}/package.json`,
+    '{\n  "prettier": {\n    "trailingComma":\n  }\n}',
+  )
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(`${tmpDir}/package.json`)
+  await Editor.setCursor(2, 20)
+
+  await Editor.openCompletion()
+
+  const completionItems = Locator('#Completions .EditorCompletionItem')
+  await expect(completionItems.nth(0)).toHaveText('all')
+  await expect(completionItems.nth(1)).toHaveText('es5')
+  await expect(completionItems.nth(2)).toHaveText('none')
+}

--- a/packages/e2e/src/json.package-json-prettier-integer-diagnostic.js
+++ b/packages/e2e/src/json.package-json-prettier-integer-diagnostic.js
@@ -1,0 +1,35 @@
+export const skip = true
+
+export const name = 'json.package-json-prettier-integer-diagnostic'
+
+export const test = async ({
+  Editor,
+  FileSystem,
+  Main,
+  Settings,
+  Workspace,
+}) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/package.json`
+  await FileSystem.writeFile(
+    uri,
+    '{\n  "prettier": {\n    "printWidth": 80.5\n  }\n}',
+  )
+  await Workspace.setPath(tmpDir)
+  await Settings.update({ 'editor.diagnostics': true })
+  await Main.openUri(uri)
+
+  await Editor.shouldHaveDiagnostics([
+    {
+      code: 'type',
+      columnIndex: 18,
+      endColumnIndex: 22,
+      endRowIndex: 2,
+      message: 'Incorrect type. Expected "integer" but received "number".',
+      rowIndex: 2,
+      source: 'json',
+      type: 'error',
+      uri,
+    },
+  ])
+}

--- a/packages/e2e/src/json.package-json-prettier-property-completion.js
+++ b/packages/e2e/src/json.package-json-prettier-property-completion.js
@@ -1,0 +1,29 @@
+export const skip = true
+
+export const name = 'json.package-json-prettier-property-completion'
+
+export const test = async ({
+  Editor,
+  expect,
+  FileSystem,
+  Locator,
+  Main,
+  Workspace,
+}) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(
+    `${tmpDir}/package.json`,
+    '{\n  "prettier": {\n    "sem"\n  }\n}',
+  )
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(`${tmpDir}/package.json`)
+  await Editor.setCursor(2, 8)
+
+  await Editor.openCompletion()
+
+  const completions = Locator('#Completions')
+  await expect(completions).toBeVisible()
+  await expect(completions.locator('.EditorCompletionItem').nth(0)).toHaveText(
+    'semi',
+  )
+}

--- a/packages/e2e/src/json.package-json-prettier-valid-diagnostics.js
+++ b/packages/e2e/src/json.package-json-prettier-valid-diagnostics.js
@@ -1,0 +1,23 @@
+export const skip = true
+
+export const name = 'json.package-json-prettier-valid-diagnostics'
+
+export const test = async ({
+  Editor,
+  FileSystem,
+  Main,
+  Settings,
+  Workspace,
+}) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/package.json`
+  await FileSystem.writeFile(
+    uri,
+    '{\n  "prettier": {\n    "semi": false,\n    "printWidth": 100,\n    "trailingComma": "all"\n  }\n}',
+  )
+  await Workspace.setPath(tmpDir)
+  await Settings.update({ 'editor.diagnostics': true })
+  await Main.openUri(uri)
+
+  await Editor.shouldHaveDiagnostics([])
+}

--- a/packages/e2e/src/json.package-json-root-property-completion.js
+++ b/packages/e2e/src/json.package-json-root-property-completion.js
@@ -1,0 +1,26 @@
+export const skip = true
+
+export const name = 'json.package-json-root-property-completion'
+
+export const test = async ({
+  Editor,
+  expect,
+  FileSystem,
+  Locator,
+  Main,
+  Workspace,
+}) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/package.json`, '{\n  "nam"\n}')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(`${tmpDir}/package.json`)
+  await Editor.setCursor(1, 6)
+
+  await Editor.openCompletion()
+
+  const completions = Locator('#Completions')
+  await expect(completions).toBeVisible()
+  await expect(completions.locator('.EditorCompletionItem').nth(0)).toHaveText(
+    'name',
+  )
+}

--- a/packages/e2e/tsconfig.json
+++ b/packages/e2e/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "ignoreDeprecations": "6.0",
     "target": "esnext",
-    "lib": ["esnext"],
+    "lib": ["esnext", "dom"],
     "checkJs": true,
     "module": "esnext",
     "types": [],

--- a/packages/extension/extension.json
+++ b/packages/extension/extension.json
@@ -5,6 +5,7 @@
   "activation": [
     "onLanguage:json",
     "onCompletion:json",
+    "onDiagnostic:json",
     "onTabCompletion:json",
     "onHover:json"
   ],
@@ -15,6 +16,12 @@
   "completionProviders": [
     {
       "id": "json.provideCompletions.json",
+      "languageId": "json"
+    }
+  ],
+  "diagnosticProviders": [
+    {
+      "id": "json.provideDiagnostics.json",
       "languageId": "json"
     }
   ],

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -36,5 +36,8 @@
   },
   "devDependencies": {
     "@lvce-editor/api": "^8.53.1"
+  },
+  "dependencies": {
+    "jsonc-parser": "^3.3.1"
   }
 }

--- a/packages/extension/src/parts/DiagnosticProvider/DiagnosticProvider.ts
+++ b/packages/extension/src/parts/DiagnosticProvider/DiagnosticProvider.ts
@@ -1,0 +1,23 @@
+import type { Diagnostic } from '@lvce-editor/api'
+import * as GetSchema from '../GetSchema/GetSchema.ts'
+import * as JsonDiagnostic from '../JsonDiagnostic/JsonDiagnostic.ts'
+
+export const id = 'json.provideDiagnostics.json'
+
+export const languageId = 'json'
+
+interface TextDocument {
+  readonly text: string
+  readonly uri: string
+}
+
+export const provideDiagnostics = async (
+  textDocument: TextDocument,
+): Promise<readonly Diagnostic[]> => {
+  const schema = await GetSchema.getSchema(textDocument.uri)
+  return JsonDiagnostic.getDiagnostics(
+    textDocument.text,
+    textDocument.uri,
+    schema,
+  )
+}

--- a/packages/extension/src/parts/GetCompletionContext/GetCompletionContext.ts
+++ b/packages/extension/src/parts/GetCompletionContext/GetCompletionContext.ts
@@ -1,0 +1,60 @@
+import {
+  findNodeAtOffset,
+  getNodePath,
+  parseTree,
+  type Node,
+} from 'jsonc-parser'
+
+export interface CompletionContext {
+  readonly kind: 'property' | 'value'
+  readonly path: readonly (number | string)[]
+}
+
+const getContainingObject = (node: Node | undefined): Node | undefined => {
+  let current = node
+  while (current && current.type !== 'object') {
+    current = current.parent
+  }
+  return current
+}
+
+export const getCompletionContext = (
+  text: string,
+  offset: number,
+): CompletionContext | undefined => {
+  const root = parseTree(text)
+  if (!root) {
+    return undefined
+  }
+  const lookupOffset = Math.max(0, Math.min(offset, text.length) - 1)
+  const node = findNodeAtOffset(root, lookupOffset, true)
+  const beforeCursor = text.slice(0, offset)
+  const missingValue = /"((?:\\.|[^"\\])*)"\s*:\s*$/.exec(beforeCursor)
+  if (missingValue) {
+    const object = getContainingObject(node)
+    return {
+      kind: 'value',
+      path: [...(object ? getNodePath(object) : []), missingValue[1]],
+    }
+  }
+  if (node?.type === 'string' && node.parent?.type === 'property') {
+    if (node.parent.children?.[0] === node) {
+      return {
+        kind: 'property',
+        path: getNodePath(node.parent.parent!),
+      }
+    }
+    return {
+      kind: 'value',
+      path: getNodePath(node),
+    }
+  }
+  const object = getContainingObject(node)
+  if (object) {
+    return {
+      kind: 'property',
+      path: getNodePath(object),
+    }
+  }
+  return undefined
+}

--- a/packages/extension/src/parts/GetPositionAt/GetPositionAt.ts
+++ b/packages/extension/src/parts/GetPositionAt/GetPositionAt.ts
@@ -1,0 +1,19 @@
+export interface Position {
+  readonly columnIndex: number
+  readonly rowIndex: number
+}
+
+export const getPositionAt = (text: string, offset: number): Position => {
+  let rowIndex = 0
+  let lastLineStart = 0
+  for (let index = 0; index < offset; index++) {
+    if (text.charCodeAt(index) === 10) {
+      rowIndex++
+      lastLineStart = index + 1
+    }
+  }
+  return {
+    columnIndex: offset - lastLineStart,
+    rowIndex,
+  }
+}

--- a/packages/extension/src/parts/GetSchema/GetSchema.ts
+++ b/packages/extension/src/parts/GetSchema/GetSchema.ts
@@ -1,14 +1,31 @@
 import * as CachedSchema from '../CachedSchemas/CachedSchemas.ts'
 import * as GetSchemaUri from '../GetSchemaUri/GetSchemaUri.ts'
+import type { JsonSchema } from '../JsonSchema/JsonSchema.ts'
+import * as LoadJsonSchemaContributions from '../LoadJsonSchemaContributions/LoadJsonSchemaContributions.ts'
 import * as LoadSchema from '../LoadSchema/LoadSchema.ts'
 
-const actual = async (uri) => {
+declare const LOAD_BUILT_IN_JSON_SCHEMAS: boolean | undefined
+
+const actual = async (uri: string): Promise<JsonSchema> => {
   const schemaUri = await GetSchemaUri.getSchemaUri(uri)
-  const schema = await LoadSchema.loadSchema(schemaUri)
-  return schema
+  const loadBuiltInSchema =
+    typeof LOAD_BUILT_IN_JSON_SCHEMAS === 'undefined' ||
+    LOAD_BUILT_IN_JSON_SCHEMAS
+  const [schema, contributions] = await Promise.all([
+    loadBuiltInSchema
+      ? (LoadSchema.loadSchema(schemaUri) as Promise<JsonSchema>)
+      : Promise.resolve({}),
+    LoadJsonSchemaContributions.loadJsonSchemaContributions(uri),
+  ])
+  if (contributions.length === 0) {
+    return schema
+  }
+  return {
+    allOf: [schema, ...contributions],
+  }
 }
 
-export const getSchema = async (uri) => {
+export const getSchema = async (uri: string): Promise<JsonSchema> => {
   if (!CachedSchema.has(uri)) {
     const schema = await actual(uri)
     CachedSchema.set(uri, schema)

--- a/packages/extension/src/parts/GetSchemaAtPath/GetSchemaAtPath.ts
+++ b/packages/extension/src/parts/GetSchemaAtPath/GetSchemaAtPath.ts
@@ -1,0 +1,43 @@
+import * as GetSchemaProperties from '../GetSchemaProperties/GetSchemaProperties.ts'
+import * as GetSchemaVariants from '../GetSchemaVariants/GetSchemaVariants.ts'
+import type { JsonSchema } from '../JsonSchema/JsonSchema.ts'
+
+const combine = (schemas: readonly JsonSchema[]): JsonSchema => {
+  if (schemas.length === 0) {
+    return {}
+  }
+  if (schemas.length === 1) {
+    return schemas[0]
+  }
+  return { allOf: schemas }
+}
+
+export const getSchemaAtPath = (
+  rootSchema: JsonSchema,
+  path: readonly (number | string)[],
+): JsonSchema => {
+  let schema = rootSchema
+  for (const segment of path) {
+    const next: JsonSchema[] = []
+    if (typeof segment === 'number') {
+      for (const variant of GetSchemaVariants.getSchemaVariants(
+        rootSchema,
+        schema,
+      )) {
+        if (variant.items) {
+          next.push(variant.items)
+        }
+      }
+    } else {
+      const property = GetSchemaProperties.getSchemaProperties(
+        rootSchema,
+        schema,
+      )?.[segment]
+      if (property) {
+        next.push(property)
+      }
+    }
+    schema = combine(next)
+  }
+  return schema
+}

--- a/packages/extension/src/parts/GetSchemaEnum/GetSchemaEnum.ts
+++ b/packages/extension/src/parts/GetSchemaEnum/GetSchemaEnum.ts
@@ -1,0 +1,20 @@
+import * as GetSchemaVariants from '../GetSchemaVariants/GetSchemaVariants.ts'
+import type { JsonSchema } from '../JsonSchema/JsonSchema.ts'
+
+export const getSchemaEnum = (
+  rootSchema: JsonSchema,
+  schema: JsonSchema,
+): readonly string[] => {
+  const values = new Set<string>()
+  for (const variant of GetSchemaVariants.getSchemaVariants(
+    rootSchema,
+    schema,
+  )) {
+    for (const value of variant.enum || []) {
+      if (typeof value === 'string') {
+        values.add(value)
+      }
+    }
+  }
+  return [...values]
+}

--- a/packages/extension/src/parts/GetSchemaProperties/GetSchemaProperties.ts
+++ b/packages/extension/src/parts/GetSchemaProperties/GetSchemaProperties.ts
@@ -1,0 +1,16 @@
+import * as GetSchemaVariants from '../GetSchemaVariants/GetSchemaVariants.ts'
+import type { JsonSchema } from '../JsonSchema/JsonSchema.ts'
+
+export const getSchemaProperties = (
+  rootSchema: JsonSchema,
+  schema: JsonSchema,
+): JsonSchema['properties'] => {
+  const properties: Record<string, JsonSchema> = {}
+  for (const variant of GetSchemaVariants.getSchemaVariants(
+    rootSchema,
+    schema,
+  )) {
+    Object.assign(properties, variant.properties)
+  }
+  return properties
+}

--- a/packages/extension/src/parts/GetSchemaTypes/GetSchemaTypes.ts
+++ b/packages/extension/src/parts/GetSchemaTypes/GetSchemaTypes.ts
@@ -1,0 +1,22 @@
+import * as GetSchemaVariants from '../GetSchemaVariants/GetSchemaVariants.ts'
+import type { JsonSchema } from '../JsonSchema/JsonSchema.ts'
+
+export const getSchemaTypes = (
+  rootSchema: JsonSchema,
+  schema: JsonSchema,
+): readonly string[] => {
+  const types = new Set<string>()
+  for (const variant of GetSchemaVariants.getSchemaVariants(
+    rootSchema,
+    schema,
+  )) {
+    if (typeof variant.type === 'string') {
+      types.add(variant.type)
+    } else {
+      for (const type of variant.type || []) {
+        types.add(type)
+      }
+    }
+  }
+  return [...types]
+}

--- a/packages/extension/src/parts/GetSchemaVariants/GetSchemaVariants.ts
+++ b/packages/extension/src/parts/GetSchemaVariants/GetSchemaVariants.ts
@@ -1,0 +1,23 @@
+import type { JsonSchema } from '../JsonSchema/JsonSchema.ts'
+import * as ResolveSchemaRef from '../ResolveSchemaRef/ResolveSchemaRef.ts'
+
+export const getSchemaVariants = (
+  rootSchema: JsonSchema,
+  schema: JsonSchema,
+): readonly JsonSchema[] => {
+  const variants: JsonSchema[] = [schema]
+  if (schema.$ref) {
+    const resolved = ResolveSchemaRef.resolveSchemaRef(rootSchema, schema.$ref)
+    if (resolved !== schema) {
+      variants.push(...getSchemaVariants(rootSchema, resolved))
+    }
+  }
+  for (const child of [
+    ...(schema.allOf || []),
+    ...(schema.anyOf || []),
+    ...(schema.oneOf || []),
+  ]) {
+    variants.push(...getSchemaVariants(rootSchema, child))
+  }
+  return variants
+}

--- a/packages/extension/src/parts/JsonCompletion/JsonCompletion.ts
+++ b/packages/extension/src/parts/JsonCompletion/JsonCompletion.ts
@@ -1,31 +1,34 @@
 import type { CompletionItem } from '@lvce-editor/api'
 import * as EnumToCompletionOption from '../EnumToCompletionOption/EnumToCompletionOption.ts'
+import * as GetCompletionContext from '../GetCompletionContext/GetCompletionContext.ts'
+import * as GetSchema from '../GetSchema/GetSchema.ts'
+import * as GetSchemaAtPath from '../GetSchemaAtPath/GetSchemaAtPath.ts'
+import * as GetSchemaEnum from '../GetSchemaEnum/GetSchemaEnum.ts'
 import * as JsonCompletionProperty from '../JsonCompletionProperty/JsonCompletionProperty.ts'
-import * as PrepareJsonDocument from '../PrepareJsonDocument/PrepareJsonDocument.ts'
 import * as QuoteString from '../QuoteString/QuoteString.ts'
-import * as TokenType from '../TokenType/TokenType.ts'
 
 export const jsonCompletion = async (
   textDocument: any,
   offset: number,
 ): Promise<readonly CompletionItem[]> => {
-  const parsed = await PrepareJsonDocument.prepareJsonDocument(
-    textDocument,
+  const context = GetCompletionContext.getCompletionContext(
+    textDocument.text,
     offset,
   )
-  if (parsed === PrepareJsonDocument.emptyDocument) {
+  if (!context) {
     return []
   }
-  const { node, schema } = parsed
-
-  if (node.type === TokenType.String) {
-    const options = schema?.properties?.type?.enum || []
+  const schema = await GetSchema.getSchema(textDocument.uri)
+  const schemaAtPath = GetSchemaAtPath.getSchemaAtPath(schema, context.path)
+  if (context.kind === 'value') {
+    const options = GetSchemaEnum.getSchemaEnum(schema, schemaAtPath)
     return options.map(EnumToCompletionOption.enumToCompletionOption)
   }
-  if (node.type === TokenType.Object) {
-    return JsonCompletionProperty.jsonCompletionProperty(schema, node)
-  }
-  return []
+  return JsonCompletionProperty.jsonCompletionProperty(
+    schema,
+    { childCount: 0, length: 0, offset, type: 1 },
+    schemaAtPath,
+  )
 }
 
 export const resolve = (textDocument, offset, name, completionItem) => {

--- a/packages/extension/src/parts/JsonCompletionProperty/JsonCompletionProperty.ts
+++ b/packages/extension/src/parts/JsonCompletionProperty/JsonCompletionProperty.ts
@@ -1,48 +1,15 @@
 import { AstNode } from '../AstNode/AstNode.ts'
 import type { CompletionItem } from '@lvce-editor/api'
+import * as GetSchemaProperties from '../GetSchemaProperties/GetSchemaProperties.ts'
 import * as PropertyKeyToCompletionOption from '../PropertyKeyToCompletionOption/PropertyKeyToCompletionOption.ts'
-import * as ResolveSchemaRef from '../ResolveSchemaRef/ResolveSchemaRef.ts'
 import type { JsonSchema } from '../JsonSchema/JsonSchema.ts'
 
-const getSchemaProperties = (
-  rootSchema: JsonSchema,
-  schema: JsonSchema,
-): JsonSchema['properties'] => {
-  if (schema.properties) {
-    return schema.properties
-  }
-
-  if (schema.$ref) {
-    const resolved = ResolveSchemaRef.resolveSchemaRef(rootSchema, schema.$ref)
-    return getSchemaProperties(rootSchema, resolved)
-  }
-
-  if (schema.allOf) {
-    const properties: { [key: string]: JsonSchema } = {}
-    for (const subSchema of schema.allOf) {
-      const subProperties = getSchemaProperties(rootSchema, subSchema)
-      Object.assign(properties, subProperties)
-    }
-    return properties
-  }
-
-  if (schema.anyOf) {
-    const properties: { [key: string]: JsonSchema } = {}
-    for (const subSchema of schema.anyOf) {
-      const subProperties = getSchemaProperties(rootSchema, subSchema)
-      Object.assign(properties, subProperties)
-    }
-    return properties
-  }
-
-  return {}
-}
-
 export const jsonCompletionProperty = (
-  schema: JsonSchema,
+  rootSchema: JsonSchema,
   node: AstNode,
+  schema: JsonSchema = rootSchema,
 ): readonly CompletionItem[] => {
-  const properties = getSchemaProperties(schema, schema)
+  const properties = GetSchemaProperties.getSchemaProperties(rootSchema, schema)
   const keys = Object.keys(properties || {})
   return keys.map(PropertyKeyToCompletionOption.propertyKeyToCompletionOption)
 }

--- a/packages/extension/src/parts/JsonDiagnostic/JsonDiagnostic.ts
+++ b/packages/extension/src/parts/JsonDiagnostic/JsonDiagnostic.ts
@@ -1,0 +1,117 @@
+import type { Diagnostic } from '@lvce-editor/api'
+import { getNodePath, parseTree, type Node } from 'jsonc-parser'
+import * as GetPositionAt from '../GetPositionAt/GetPositionAt.ts'
+import * as GetSchemaAtPath from '../GetSchemaAtPath/GetSchemaAtPath.ts'
+import * as GetSchemaEnum from '../GetSchemaEnum/GetSchemaEnum.ts'
+import * as GetSchemaTypes from '../GetSchemaTypes/GetSchemaTypes.ts'
+import type { JsonSchema } from '../JsonSchema/JsonSchema.ts'
+
+const getActualType = (node: Node): string => {
+  return node.type
+}
+
+const isExpectedType = (
+  node: Node,
+  expectedTypes: readonly string[],
+): boolean => {
+  if (expectedTypes.length === 0) {
+    return true
+  }
+  if (expectedTypes.includes(node.type)) {
+    return true
+  }
+  return (
+    node.type === 'number' &&
+    expectedTypes.includes('integer') &&
+    Number.isInteger(node.value)
+  )
+}
+
+const createDiagnostic = (
+  text: string,
+  uri: string,
+  node: Node,
+  code: string,
+  message: string,
+): Diagnostic => {
+  const start = GetPositionAt.getPositionAt(text, node.offset)
+  const end = GetPositionAt.getPositionAt(text, node.offset + node.length)
+  return {
+    code,
+    columnIndex: start.columnIndex,
+    endColumnIndex: end.columnIndex,
+    endRowIndex: end.rowIndex,
+    message,
+    rowIndex: start.rowIndex,
+    source: 'json',
+    type: 'error',
+    uri,
+  }
+}
+
+const validateNode = (
+  text: string,
+  uri: string,
+  rootSchema: JsonSchema,
+  node: Node,
+  diagnostics: Diagnostic[],
+): void => {
+  const path = getNodePath(node)
+  const schema = GetSchemaAtPath.getSchemaAtPath(rootSchema, path)
+  const expectedTypes = GetSchemaTypes.getSchemaTypes(rootSchema, schema)
+  if (!isExpectedType(node, expectedTypes)) {
+    const expected = expectedTypes.map((type) => `"${type}"`).join(' or ')
+    diagnostics.push(
+      createDiagnostic(
+        text,
+        uri,
+        node,
+        'type',
+        `Incorrect type. Expected ${expected} but received "${getActualType(node)}".`,
+      ),
+    )
+    return
+  }
+  const allowedValues = GetSchemaEnum.getSchemaEnum(rootSchema, schema)
+  if (
+    allowedValues.length > 0 &&
+    typeof node.value === 'string' &&
+    !allowedValues.includes(node.value)
+  ) {
+    diagnostics.push(
+      createDiagnostic(
+        text,
+        uri,
+        node,
+        'enum',
+        `Value is not accepted. Valid values: ${allowedValues.map((value) => `"${value}"`).join(', ')}.`,
+      ),
+    )
+  }
+  if (node.type === 'object') {
+    for (const property of node.children || []) {
+      const value = property.children?.[1]
+      if (value) {
+        validateNode(text, uri, rootSchema, value, diagnostics)
+      }
+    }
+  } else if (node.type === 'array') {
+    for (const child of node.children || []) {
+      validateNode(text, uri, rootSchema, child, diagnostics)
+    }
+  }
+}
+
+export const getDiagnostics = (
+  text: string,
+  uri: string,
+  schema: JsonSchema,
+): readonly Diagnostic[] => {
+  const root = parseTree(text)
+  if (!root) {
+    return []
+  }
+  const diagnostics: Diagnostic[] = []
+  validateNode(text, uri, schema, root, diagnostics)
+  return diagnostics
+}

--- a/packages/extension/src/parts/JsonSchema/JsonSchema.ts
+++ b/packages/extension/src/parts/JsonSchema/JsonSchema.ts
@@ -1,5 +1,6 @@
 export interface JsonSchema {
   readonly $ref?: string
+  readonly additionalProperties?: boolean | JsonSchema
   readonly properties?: {
     readonly [key: string]: JsonSchema
   }
@@ -8,7 +9,10 @@ export interface JsonSchema {
   }
   readonly allOf?: readonly JsonSchema[]
   readonly anyOf?: readonly JsonSchema[]
+  readonly oneOf?: readonly JsonSchema[]
   readonly description?: string
-  readonly type?: string
-  readonly enum?: readonly string[]
+  readonly type?: string | readonly string[]
+  readonly enum?: readonly unknown[]
+  readonly items?: JsonSchema
+  readonly minimum?: number
 }

--- a/packages/extension/src/parts/JsonSchemaContributions/JsonSchemaContributions.ts
+++ b/packages/extension/src/parts/JsonSchemaContributions/JsonSchemaContributions.ts
@@ -1,0 +1,27 @@
+import { getJsonSchemas, type JsonSchemaContribution } from '@lvce-editor/api'
+
+let schemas: readonly JsonSchemaContribution[] | undefined
+let schemasPromise: Promise<readonly JsonSchemaContribution[]> | undefined
+
+declare const JSON_SCHEMA_CONTRIBUTIONS:
+  | readonly JsonSchemaContribution[]
+  | undefined
+
+export const initialize = (): void => {
+  const builtInSchemas =
+    typeof JSON_SCHEMA_CONTRIBUTIONS === 'undefined'
+      ? []
+      : JSON_SCHEMA_CONTRIBUTIONS
+  if (builtInSchemas.length > 0) {
+    schemas = builtInSchemas
+  }
+}
+
+export const get = async (): Promise<readonly JsonSchemaContribution[]> => {
+  if (schemas) {
+    return schemas
+  }
+  schemasPromise ||= getJsonSchemas()
+  schemas = await schemasPromise
+  return schemas
+}

--- a/packages/extension/src/parts/LanguageFeatures/LanguageFeatures.ts
+++ b/packages/extension/src/parts/LanguageFeatures/LanguageFeatures.ts
@@ -1,14 +1,17 @@
 import {
   registerCompletionProvider,
+  registerDiagnosticProvider,
   registerHoverProvider,
   registerSelectionProvider,
 } from '@lvce-editor/api'
 import * as CompletionProvider from '../CompletionProvider/CompletionProvider.ts'
+import * as DiagnosticProvider from '../DiagnosticProvider/DiagnosticProvider.ts'
 import * as HoverProvider from '../HoverProvider/HoverProvider.ts'
 import * as SelectionProvider from '../SelectionProvider/SelectionProvider.ts'
 
 export const register = (): void => {
   registerSelectionProvider(SelectionProvider)
   registerCompletionProvider(CompletionProvider)
+  registerDiagnosticProvider(DiagnosticProvider)
   registerHoverProvider(HoverProvider)
 }

--- a/packages/extension/src/parts/LoadJsonSchemaContributions/LoadJsonSchemaContributions.ts
+++ b/packages/extension/src/parts/LoadJsonSchemaContributions/LoadJsonSchemaContributions.ts
@@ -1,0 +1,45 @@
+import type { JsonSchemaContribution } from '@lvce-editor/api'
+import type { JsonSchema } from '../JsonSchema/JsonSchema.ts'
+import * as JsonSchemaContributions from '../JsonSchemaContributions/JsonSchemaContributions.ts'
+import * as MatchesJsonSchema from '../MatchesJsonSchema/MatchesJsonSchema.ts'
+
+interface JsonSchemaContributionWithSchema extends JsonSchemaContribution {
+  readonly schema?: JsonSchema
+}
+
+const loadJson = async (
+  contribution: JsonSchemaContributionWithSchema,
+): Promise<JsonSchema> => {
+  if (contribution.schema) {
+    return contribution.schema
+  }
+  const schemaUrl = new URL(contribution.url, import.meta.url).href
+  const response = await fetch(schemaUrl)
+  if (!response.ok) {
+    throw new Error(
+      `Failed to load JSON schema ${schemaUrl}: ${response.statusText}`,
+    )
+  }
+  return response.json() as Promise<JsonSchema>
+}
+
+export const loadJsonSchemaContributions = async (
+  uri: string,
+): Promise<readonly JsonSchema[]> => {
+  const contributions = await JsonSchemaContributions.get()
+  const matching = contributions.filter((contribution) =>
+    MatchesJsonSchema.matchesJsonSchema(uri, contribution),
+  )
+  const results = await Promise.allSettled(
+    matching.map((contribution) => loadJson(contribution)),
+  )
+  const schemas: JsonSchema[] = []
+  for (const result of results) {
+    if (result.status === 'fulfilled') {
+      schemas.push(result.value)
+    } else {
+      console.warn(result.reason)
+    }
+  }
+  return schemas
+}

--- a/packages/extension/src/parts/Main/Main.ts
+++ b/packages/extension/src/parts/Main/Main.ts
@@ -1,4 +1,5 @@
 import { activate as activateExtensionApi } from '@lvce-editor/api'
+import * as JsonSchemaContributions from '../JsonSchemaContributions/JsonSchemaContributions.ts'
 import * as LanguageFeatures from '../LanguageFeatures/LanguageFeatures.ts'
 
 const state = {
@@ -11,6 +12,7 @@ export const activate = async (): Promise<void> => {
   }
   state.isActivated = true
   await activateExtensionApi()
+  JsonSchemaContributions.initialize()
   LanguageFeatures.register()
 }
 

--- a/packages/extension/src/parts/MatchesJsonSchema/MatchesJsonSchema.ts
+++ b/packages/extension/src/parts/MatchesJsonSchema/MatchesJsonSchema.ts
@@ -1,0 +1,25 @@
+import type { JsonSchemaContribution } from '@lvce-editor/api'
+
+const getBaseName = (uri: string): string => {
+  const withoutQuery = uri.split(/[?#]/, 1)[0]
+  return withoutQuery.slice(withoutQuery.lastIndexOf('/') + 1)
+}
+
+const matchesPattern = (fileName: string, pattern: string): boolean => {
+  const escaped = pattern
+    .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+    .replaceAll('*', '.*')
+  return new RegExp(`^${escaped}$`).test(fileName)
+}
+
+export const matchesJsonSchema = (
+  uri: string,
+  contribution: JsonSchemaContribution,
+): boolean => {
+  const fileName = getBaseName(uri)
+  const patterns =
+    typeof contribution.fileMatch === 'string'
+      ? [contribution.fileMatch]
+      : contribution.fileMatch
+  return patterns.some((pattern) => matchesPattern(fileName, pattern))
+}

--- a/packages/extension/src/parts/ResolveSchemaRef/ResolveSchemaRef.ts
+++ b/packages/extension/src/parts/ResolveSchemaRef/ResolveSchemaRef.ts
@@ -1,18 +1,33 @@
 import type { JsonSchema } from '../JsonSchema/JsonSchema.ts'
 
-const definitionPrefix = '#/definitions/'
-
 export const resolveSchemaRef = (
   schema: JsonSchema,
   ref: string,
 ): JsonSchema => {
-  if (!ref.startsWith(definitionPrefix)) {
+  if (!ref.startsWith('#/')) {
     return {}
   }
-  const path = ref.slice(definitionPrefix.length)
-  const resolved = schema.definitions?.[path]
-  if (!resolved) {
-    return {}
+  const segments = ref
+    .slice(2)
+    .split('/')
+    .map((segment) => segment.replaceAll('~1', '/').replaceAll('~0', '~'))
+  const candidates = [
+    schema,
+    ...(schema.allOf || []),
+    ...(schema.anyOf || []),
+    ...(schema.oneOf || []),
+  ]
+  for (const candidate of candidates) {
+    let current: any = candidate
+    for (const segment of segments) {
+      current = current?.[segment]
+      if (!current) {
+        break
+      }
+    }
+    if (current) {
+      return current
+    }
   }
-  return resolved
+  return {}
 }

--- a/packages/extension/test/GetCompletionContext.test.ts
+++ b/packages/extension/test/GetCompletionContext.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@jest/globals'
+import * as GetCompletionContext from '../src/parts/GetCompletionContext/GetCompletionContext.ts'
+
+test('gets root property completion context', () => {
+  const text = '{ "nam" }'
+  expect(GetCompletionContext.getCompletionContext(text, 6)).toEqual({
+    kind: 'property',
+    path: [],
+  })
+})
+
+test('gets nested property completion context', () => {
+  const text = '{ "prettier": { "sem" } }'
+  expect(GetCompletionContext.getCompletionContext(text, 21)).toEqual({
+    kind: 'property',
+    path: ['prettier'],
+  })
+})
+
+test('gets a string value completion context', () => {
+  const text = '{ "type": "mod" }'
+  expect(GetCompletionContext.getCompletionContext(text, 15)).toEqual({
+    kind: 'value',
+    path: ['type'],
+  })
+})
+
+test('gets a missing nested value completion context', () => {
+  const text = '{ "prettier": { "trailingComma":  } }'
+  expect(GetCompletionContext.getCompletionContext(text, 34)).toEqual({
+    kind: 'value',
+    path: ['prettier', 'trailingComma'],
+  })
+})

--- a/packages/extension/test/JsonDiagnostic.test.ts
+++ b/packages/extension/test/JsonDiagnostic.test.ts
@@ -1,0 +1,79 @@
+import { expect, test } from '@jest/globals'
+import * as JsonDiagnostic from '../src/parts/JsonDiagnostic/JsonDiagnostic.ts'
+
+const schema = {
+  type: 'object',
+  properties: {
+    prettier: {
+      type: 'object',
+      properties: {
+        semi: { type: 'boolean' },
+        printWidth: { type: 'integer' },
+        trailingComma: { type: 'string', enum: ['all', 'es5', 'none'] },
+      },
+    },
+  },
+} as const
+
+test('reports a nested boolean type mismatch', () => {
+  const text = '{\n  "prettier": {\n    "semi": "yes"\n  }\n}'
+  expect(
+    JsonDiagnostic.getDiagnostics(
+      text,
+      'file:///workspace/package.json',
+      schema,
+    ),
+  ).toEqual([
+    {
+      code: 'type',
+      columnIndex: 12,
+      endColumnIndex: 17,
+      endRowIndex: 2,
+      message: 'Incorrect type. Expected "boolean" but received "string".',
+      rowIndex: 2,
+      source: 'json',
+      type: 'error',
+      uri: 'file:///workspace/package.json',
+    },
+  ])
+})
+
+test('reports an integer type mismatch', () => {
+  const text = '{ "prettier": { "printWidth": 80.5 } }'
+  expect(
+    JsonDiagnostic.getDiagnostics(
+      text,
+      'file:///workspace/package.json',
+      schema,
+    )[0],
+  ).toMatchObject({
+    code: 'type',
+    message: 'Incorrect type. Expected "integer" but received "number".',
+  })
+})
+
+test('reports an invalid enum value', () => {
+  const text = '{ "prettier": { "trailingComma": "sometimes" } }'
+  expect(
+    JsonDiagnostic.getDiagnostics(
+      text,
+      'file:///workspace/package.json',
+      schema,
+    )[0],
+  ).toMatchObject({
+    code: 'enum',
+    message: 'Value is not accepted. Valid values: "all", "es5", "none".',
+  })
+})
+
+test('accepts valid prettier values', () => {
+  const text =
+    '{ "prettier": { "semi": false, "printWidth": 100, "trailingComma": "all" } }'
+  expect(
+    JsonDiagnostic.getDiagnostics(
+      text,
+      'file:///workspace/package.json',
+      schema,
+    ),
+  ).toEqual([])
+})

--- a/packages/extension/test/MatchesJsonSchema.test.ts
+++ b/packages/extension/test/MatchesJsonSchema.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@jest/globals'
+import * as MatchesJsonSchema from '../src/parts/MatchesJsonSchema/MatchesJsonSchema.ts'
+
+test('matches an exact package.json file name', () => {
+  expect(
+    MatchesJsonSchema.matchesJsonSchema('file:///workspace/package.json', {
+      fileMatch: 'package.json',
+      url: '/schema.json',
+    }),
+  ).toBe(true)
+})
+
+test('does not match a different file name', () => {
+  expect(
+    MatchesJsonSchema.matchesJsonSchema('file:///workspace/package-lock.json', {
+      fileMatch: 'package.json',
+      url: '/schema.json',
+    }),
+  ).toBe(false)
+})
+
+test('matches wildcard patterns', () => {
+  expect(
+    MatchesJsonSchema.matchesJsonSchema(
+      'file:///workspace/tsconfig.test.json',
+      {
+        fileMatch: 'tsconfig.*.json',
+        url: '/schema.json',
+      },
+    ),
+  ).toBe(true)
+})
+
+test('matches any pattern in an array', () => {
+  expect(
+    MatchesJsonSchema.matchesJsonSchema(
+      'file:///workspace/.prettierrc.json?raw=1',
+      {
+        fileMatch: ['.prettierrc', '.prettierrc.json'],
+        url: '/schema.json',
+      },
+    ),
+  ).toBe(true)
+})

--- a/packages/integration/src/startWorker.ts
+++ b/packages/integration/src/startWorker.ts
@@ -19,12 +19,26 @@ const getModuleUrl = (name: string): string => {
 }
 
 export const startWorker = async () => {
+  const JsonSchemaContributions = await import(
+    getModuleUrl('JsonSchemaContributions')
+  )
+  await JsonSchemaContributions.initialize()
   const JsonCompletion = await import(getModuleUrl('JsonCompletion'))
+  const JsonDiagnostic = await import(getModuleUrl('JsonDiagnostic'))
+  const GetSchema = await import(getModuleUrl('GetSchema'))
   const JsonHover = await import(getModuleUrl('JsonHover'))
   const Selection = await import(getModuleUrl('Selection'))
   const commandMap = {
     'Completion.getCompletion': JsonCompletion.jsonCompletion,
     'Completion.resolve': JsonCompletion.resolve,
+    async 'Diagnostic.getDiagnostics'(textDocument: any) {
+      const schema = await GetSchema.getSchema(textDocument.uri)
+      return JsonDiagnostic.getDiagnostics(
+        textDocument.text,
+        textDocument.uri,
+        schema,
+      )
+    },
     'Hover.getHover': JsonHover.getHover,
     'Selection.expand': Selection.expand,
   }

--- a/packages/integration/src/testWorker.ts
+++ b/packages/integration/src/testWorker.ts
@@ -2,8 +2,24 @@
 // send and receive messages
 
 import { startWorker } from './startWorker.ts'
+import { jest } from '@jest/globals'
 
-export const testWorker = async ({ execMap }) => {
+let currentJsonSchemas: readonly unknown[] = []
+
+jest.unstable_mockModule('@lvce-editor/api', () => ({
+  getJsonSchemas: async () => currentJsonSchemas,
+}))
+
+interface TestWorkerOptions {
+  readonly execMap: Record<string, (...args: any[]) => any>
+  readonly jsonSchemas?: readonly any[]
+}
+
+export const testWorker = async ({
+  execMap,
+  jsonSchemas = [],
+}: TestWorkerOptions) => {
+  currentJsonSchemas = jsonSchemas
   const invocations: any[][] = []
   const worker = await startWorker()
   return {

--- a/packages/integration/test/package-json-schema-contribution.test.ts
+++ b/packages/integration/test/package-json-schema-contribution.test.ts
@@ -1,0 +1,153 @@
+import { expect, test } from '@jest/globals'
+import { testWorker } from '../src/testWorker.ts'
+
+const packageSchema = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+  },
+}
+
+const prettierPackageSchema = {
+  type: 'object',
+  properties: {
+    prettier: {
+      type: 'object',
+      properties: {
+        semi: { type: 'boolean' },
+        singleQuote: { type: 'boolean' },
+        printWidth: { type: 'integer' },
+        trailingComma: { type: 'string', enum: ['all', 'es5', 'none'] },
+      },
+    },
+  },
+}
+
+const createWorker = async () => {
+  return testWorker({
+    execMap: {
+      'Json.loadSchema'(input: string) {
+        return input.endsWith('/prettier-package.schema.json')
+          ? prettierPackageSchema
+          : packageSchema
+      },
+    },
+    jsonSchemas: [
+      {
+        fileMatch: 'package.json',
+        url: 'https://example.com/prettier-package.schema.json',
+      },
+    ],
+  })
+}
+
+test('combines root properties from the built-in and contributed schemas', async () => {
+  const worker = await createWorker()
+  const textDocument = {
+    uri: 'test://completion-root/package.json',
+    text: '{ "" }',
+  }
+  const result = await worker.execute(
+    'Completion.getCompletion',
+    textDocument,
+    3,
+  )
+  expect(result).toEqual(
+    expect.arrayContaining([
+      { kind: 1, label: 'name' },
+      { kind: 1, label: 'prettier' },
+    ]),
+  )
+})
+
+test('completes prettier option names inside package.json', async () => {
+  const worker = await createWorker()
+  const textDocument = {
+    uri: 'test://completion-options/package.json',
+    text: '{ "prettier": { "sem" } }',
+  }
+  const result = await worker.execute(
+    'Completion.getCompletion',
+    textDocument,
+    21,
+  )
+  expect(result).toEqual(
+    expect.arrayContaining([
+      { kind: 1, label: 'semi' },
+      { kind: 1, label: 'singleQuote' },
+      { kind: 1, label: 'printWidth' },
+      { kind: 1, label: 'trailingComma' },
+    ]),
+  )
+})
+
+test('completes enum values from the contributed schema', async () => {
+  const worker = await createWorker()
+  const textDocument = {
+    uri: 'test://completion-enum/package.json',
+    text: '{ "prettier": { "trailingComma":  } }',
+  }
+  expect(
+    await worker.execute('Completion.getCompletion', textDocument, 34),
+  ).toEqual([
+    { kind: 2, label: 'all' },
+    { kind: 2, label: 'es5' },
+    { kind: 2, label: 'none' },
+  ])
+})
+
+test('reports an invalid prettier option type', async () => {
+  const worker = await createWorker()
+  const textDocument = {
+    uri: 'test://diagnostic-type/package.json',
+    text: '{ "prettier": { "semi": "no" } }',
+  }
+  expect(
+    await worker.execute('Diagnostic.getDiagnostics', textDocument),
+  ).toEqual([
+    expect.objectContaining({
+      code: 'type',
+      message: 'Incorrect type. Expected "boolean" but received "string".',
+      source: 'json',
+      type: 'error',
+    }),
+  ])
+})
+
+test('reports an invalid prettier enum value', async () => {
+  const worker = await createWorker()
+  const textDocument = {
+    uri: 'test://diagnostic-enum/package.json',
+    text: '{ "prettier": { "trailingComma": "sometimes" } }',
+  }
+  expect(
+    await worker.execute('Diagnostic.getDiagnostics', textDocument),
+  ).toEqual([
+    expect.objectContaining({
+      code: 'enum',
+      message: 'Value is not accepted. Valid values: "all", "es5", "none".',
+    }),
+  ])
+})
+
+test('accepts valid prettier configuration values', async () => {
+  const worker = await createWorker()
+  const textDocument = {
+    uri: 'test://diagnostic-valid/package.json',
+    text: '{ "prettier": { "semi": false, "printWidth": 100, "trailingComma": "all" } }',
+  }
+  expect(
+    await worker.execute('Diagnostic.getDiagnostics', textDocument),
+  ).toEqual([])
+})
+
+test('does not apply the contribution to other JSON files', async () => {
+  const worker = await createWorker()
+  const textDocument = {
+    uri: 'test://other/settings.json',
+    text: '{ "prettier": { "semi": "no" } }',
+  }
+  expect(
+    await worker.execute('Diagnostic.getDiagnostics', textDocument),
+  ).toEqual([])
+})


### PR DESCRIPTION
## Summary\n- merge extension-contributed schemas with built-in JSON schemas\n- complete nested property names and enum values\n- validate contributed schema types and enums through a diagnostic provider\n- add unit, provider integration, and browser regression coverage\n- update the browser test runtime\n\n## Tests\n- 30 extension unit tests\n- 10 provider integration tests\n- type-check\n- 6 browser regression cases added; currently skipped because the browser runtime does not dispatch the repository's completion or diagnostic providers (the pre-existing provider e2e cases are skipped for the same reason)