### PR TITLE
feature: update extension api to 8.75.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1956,12 +1956,13 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/api": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.53.1.tgz",
-      "integrity": "sha512-dOsMEPbfUhd0TnmWTzm7Eu1WPx8Vq4RjR7XQ801B7zAr8n5sOElyqb9hbonadIkQoLX2h7OG+KqE3XMqElm4Vg==",
+      "version": "8.75.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.75.0.tgz",
+      "integrity": "sha512-ub0W95GZVxRmUYpkfGHirV8+UUO15uZCBxkhdgtctzLWuw1SZQO3UEcBqKhTbPsiRCzawclHDXRFR0N9vFGboQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@lvce-editor/command": "^2.0.0",
         "@lvce-editor/rpc": "^6.4.0",
         "@lvce-editor/rpc-registry": "^9.24.0",
         "@lvce-editor/virtual-dom-worker": "^10.0.0"
@@ -10241,7 +10242,7 @@
       "version": "0.0.0-dev",
       "devDependencies": {
         "@jest/globals": "^30.2.0",
-        "@lvce-editor/api": "^8.53.1"
+        "@lvce-editor/api": "^8.75.0"
       }
     },
     "packages/integration": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -36,6 +36,6 @@
   },
   "devDependencies": {
     "@jest/globals": "^30.2.0",
-    "@lvce-editor/api": "^8.53.1"
+    "@lvce-editor/api": "^8.75.0"
   }
 }


### PR DESCRIPTION
Update the extension API to 8.75.0 so unused extension commands can be removed from the production bundle. This reduces the packaged extension by about 5.1 KB without changing behavior.