### PR TITLE
fix: show version and last updated date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2350,19 +2350,21 @@
       }
     },
     "node_modules/@lvce-editor/package-extension": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/package-extension/-/package-extension-1.6.0.tgz",
-      "integrity": "sha512-K3qxzA/6q+joaes9xn7YeLDaZk2yhdsqQJcCQX55hbb5+zT2XWi6zZvjo3dzSpwKDAibQlam1iWN+xFr1/0/CA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/package-extension/-/package-extension-3.7.0.tgz",
+      "integrity": "sha512-LGJiQWSs0en4Wwo+2UAejsNKQMZJ316Zpt9hRllypdrxWrcoQtqCt6TMpNUce1tt5JyHVgyqwVZ/0PorwEzjEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/preset-typescript": "^7.27.1",
+        "@babel/preset-typescript": "^7.28.5",
         "@lvce-editor/verror": "^1.7.0",
-        "@rollup/plugin-babel": "^6.0.4",
-        "@rollup/plugin-node-resolve": "^16.0.1",
-        "execa": "^9.6.0",
-        "rollup": "^4.48.0",
-        "tar-fs": "^3.1.0"
+        "@rollup/plugin-babel": "^6.1.0",
+        "@rollup/plugin-commonjs": "^29.0.0",
+        "@rollup/plugin-json": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^16.0.3",
+        "execa": "^9.6.1",
+        "rollup": "^4.53.3",
+        "tar-fs": "^3.1.1"
       }
     },
     "node_modules/@lvce-editor/preload": {
@@ -3658,6 +3660,54 @@
         "@types/babel__core": {
           "optional": true
         },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-29.0.3.tgz",
+      "integrity": "sha512-ZaOxZceP7SOUW7Lqw5IRVweSQYWaeIPnXIGLiB690EBA3FGJTO40EEr2L5yZplJWsgTCogILRSpcAe7+U0Otdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.2",
+        "fdir": "^6.2.0",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.30.3",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0 || 14 >= 14.17"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-json": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
+      "integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
         "rollup": {
           "optional": true
         }
@@ -5608,6 +5658,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6708,6 +6765,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
       }
     },
     "node_modules/is-stream": {
@@ -8180,6 +8247,16 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
@@ -10487,7 +10564,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@lvce-editor/package-extension": "^1.4.0",
+        "@lvce-editor/package-extension": "^3.7.0",
         "@lvce-editor/shared-process": "^0.103.19",
         "esbuild": "^0.28.1"
       }

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -4,12 +4,14 @@
   "description": "",
   "type": "module",
   "main": "index.js",
-  "scripts": {},
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@lvce-editor/package-extension": "^1.4.0",
+    "@lvce-editor/package-extension": "^3.7.0",
     "@lvce-editor/shared-process": "^0.103.19",
     "esbuild": "^0.28.1"
   }

--- a/packages/build/test/packageExtensionMetadata.test.js
+++ b/packages/build/test/packageExtensionMetadata.test.js
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { packageExtension } from '@lvce-editor/package-extension'
+
+test('adds version and last updated metadata to the packaged extension', async () => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), 'language-features-json-package-'),
+  )
+  const extensionDirectory = join(temporaryDirectory, 'extension')
+  const extensionJsonPath = join(extensionDirectory, 'extension.json')
+  const gitCommitDate = 1_724_544_000
+
+  try {
+    await mkdir(extensionDirectory)
+    await writeFile(
+      extensionJsonPath,
+      JSON.stringify({ id: 'builtin.language-features-json' }),
+    )
+
+    await packageExtension({
+      env: {
+        GIT_COMMIT_DATE: String(gitCommitDate),
+        GIT_TAG: 'v1.2.3',
+      },
+      inDir: extensionDirectory,
+      outFile: join(temporaryDirectory, 'extension.tar.br'),
+    })
+
+    const extensionJson = JSON.parse(
+      await readFile(extensionJsonPath, 'utf8'),
+    )
+    assert.equal(extensionJson.version, '1.2.3')
+    assert.equal(extensionJson.lastUpdated, '2024-08-25T00:00:00.000Z')
+  } finally {
+    await rm(temporaryDirectory, { force: true, recursive: true })
+  }
+})


### PR DESCRIPTION
Updates the extension packaging dependency so release builds include version and last-updated metadata in the extension detail view. Adds a focused regression test for both generated fields.