### PR TITLE
feature: complete extension settings in settings json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1958,16 +1958,16 @@
       "optional": true
     },
     "node_modules/@lvce-editor/api": {
-      "version": "8.75.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.75.0.tgz",
-      "integrity": "sha512-ub0W95GZVxRmUYpkfGHirV8+UUO15uZCBxkhdgtctzLWuw1SZQO3UEcBqKhTbPsiRCzawclHDXRFR0N9vFGboQ==",
+      "version": "9.27.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-9.27.0.tgz",
+      "integrity": "sha512-uCzPYgs/TWjirrMsNx/XiO3zTsyZILBFXzYvmP5+reHQNXBZV8ZlYsoKKoXfLd7LoHQu0q2pGz7MNxwpORxEnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/command": "^2.0.0",
         "@lvce-editor/rpc": "^6.4.0",
         "@lvce-editor/rpc-registry": "^9.24.0",
-        "@lvce-editor/virtual-dom-worker": "^10.0.0"
+        "@lvce-editor/virtual-dom-worker": "^11.2.0"
       }
     },
     "node_modules/@lvce-editor/assert": {
@@ -2842,13 +2842,13 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/virtual-dom-worker": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom-worker/-/virtual-dom-worker-10.2.0.tgz",
-      "integrity": "sha512-URtDWcAFadP7SLOqfepRxomJmNRQDmON8GFKRfsA1dOgcqBnoBR4G5xwo6oDeZvP4pnRAzHR3QB3b8I6nASU+w==",
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom-worker/-/virtual-dom-worker-11.15.0.tgz",
+      "integrity": "sha512-WiH5ne+EwtcqLJC5tqAe3AjX4iO00+zxMMjSrJKjn0/pJcdpGFTqC5dSiEtzhnmbyPIN/yIBsikaPMSQ7swWEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/constants": "^5.14.0"
+        "@lvce-editor/constants": "^5.29.0"
       }
     },
     "node_modules/@lvce-editor/web-socket-server": {
@@ -10581,7 +10581,7 @@
       "version": "0.0.0-dev",
       "devDependencies": {
         "@jest/globals": "^30.2.0",
-        "@lvce-editor/api": "^8.75.0"
+        "@lvce-editor/api": "^9.27.0"
       }
     },
     "packages/integration": {

--- a/packages/build/src/build-e2e-extension.js
+++ b/packages/build/src/build-e2e-extension.js
@@ -1,0 +1,17 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { root } from './root.js'
+
+const source = path.join(
+  root,
+  'packages',
+  'extension',
+  'dist',
+  'languageFeaturesJsonMain.js',
+)
+const targetDirectory = path.join(root, 'packages', 'e2e', 'extension', 'dist')
+const target = path.join(targetDirectory, 'languageFeaturesJsonMain.js')
+
+fs.rmSync(targetDirectory, { recursive: true, force: true })
+fs.mkdirSync(targetDirectory, { recursive: true })
+fs.copyFileSync(source, target)

--- a/packages/e2e/extension/extension.json
+++ b/packages/e2e/extension/extension.json
@@ -1,0 +1,39 @@
+{
+  "id": "builtin.language-features-json",
+  "name": "Language Features json",
+  "description": "Provides rich language support for JSON files during end-to-end tests",
+  "activation": [
+    "onLanguage:json",
+    "onCompletion:json",
+    "onTabCompletion:json",
+    "onHover:json"
+  ],
+  "browser": "dist/languageFeaturesJsonMain.js",
+  "isolated": true,
+  "commands": [],
+  "completionProviders": [
+    {
+      "id": "json.provideCompletions.json",
+      "languageId": "json"
+    }
+  ],
+  "configuration": {
+    "gptvoice.tools.terminal.enabled": {
+      "type": "boolean",
+      "default": false,
+      "description": "Allow Gpt Voice to execute Bash commands in the opened workspace."
+    }
+  },
+  "hoverProviders": [
+    {
+      "id": "json.provideHover.json",
+      "languageId": "json"
+    }
+  ],
+  "languages": [
+    {
+      "id": "json",
+      "extensions": [".json"]
+    }
+  ]
+}

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build:extension": "node ../build/src/build-extension.js",
-    "e2e": "npm run build:extension && test-with-playwright --only-extension=../extension --test-path=.",
-    "e2e:headless": "npm run build:extension && test-with-playwright --only-extension=../extension --test-path=. --headless"
+    "build:extension": "node ../build/src/build-extension.js && node ../build/src/build-e2e-extension.js",
+    "e2e": "npm run build:extension && test-with-playwright --only-extension=./extension --test-path=.",
+    "e2e:headless": "npm run build:extension && test-with-playwright --only-extension=./extension --test-path=. --headless"
   },
   "type": "module",
   "keywords": [],

--- a/packages/e2e/src/json.settings-completion.ts
+++ b/packages/e2e/src/json.settings-completion.ts
@@ -11,6 +11,7 @@ export const test: Test = async ({ Command, Editor, expect, Locator }) => {
   const completions = Locator('#Completions')
   await expect(completions).toBeVisible()
   const completionItems = completions.locator('.EditorCompletionItem')
-  await expect(completionItems.nth(0)).toHaveText('editor.fontSize')
-  await expect(completionItems.nth(1)).toHaveText('editor.fontFamily')
+  await expect(completionItems.nth(0)).toHaveText(
+    'gptvoice.tools.terminal.enabled',
+  )
 }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -36,6 +36,6 @@
   },
   "devDependencies": {
     "@jest/globals": "^30.2.0",
-    "@lvce-editor/api": "^8.75.0"
+    "@lvce-editor/api": "^9.27.0"
   }
 }

--- a/packages/extension/src/parts/CreateSettingsSchema/CreateSettingsSchema.ts
+++ b/packages/extension/src/parts/CreateSettingsSchema/CreateSettingsSchema.ts
@@ -47,6 +47,7 @@ const createPropertySchema = (setting: SettingItem): JsonSchema => {
 
 export const createSettingsSchema = (
   contributions: readonly (readonly SettingItem[])[],
+  extensionDefinitions: Readonly<Record<string, JsonSchema>> = {},
 ): JsonSchema => {
   const properties: Record<string, JsonSchema> = {}
   for (const contribution of contributions) {
@@ -55,7 +56,10 @@ export const createSettingsSchema = (
     }
   }
   return {
-    properties,
+    properties: {
+      ...extensionDefinitions,
+      ...properties,
+    },
     type: 'object',
   }
 }

--- a/packages/extension/src/parts/LoadSettingsSchema/LoadSettingsSchema.ts
+++ b/packages/extension/src/parts/LoadSettingsSchema/LoadSettingsSchema.ts
@@ -1,3 +1,4 @@
+import { getConfigurationDefinitions } from '@lvce-editor/api'
 import * as CreateSettingsSchema from '../CreateSettingsSchema/CreateSettingsSchema.ts'
 import type { JsonSchema } from '../JsonSchema/JsonSchema.ts'
 import type { SettingItem } from '../SettingItem/SettingItem.ts'
@@ -7,5 +8,9 @@ declare const BUILTIN_SETTINGS: readonly (readonly SettingItem[])[] | undefined
 export const loadSettingsSchema = async (): Promise<JsonSchema> => {
   const contributions =
     typeof BUILTIN_SETTINGS === 'undefined' ? [] : BUILTIN_SETTINGS
-  return CreateSettingsSchema.createSettingsSchema(contributions)
+  const extensionDefinitions = await getConfigurationDefinitions()
+  return CreateSettingsSchema.createSettingsSchema(
+    contributions,
+    extensionDefinitions,
+  )
 }

--- a/packages/extension/test/CreateSettingsSchema.test.ts
+++ b/packages/extension/test/CreateSettingsSchema.test.ts
@@ -3,48 +3,58 @@ import * as CreateSettingsSchema from '../src/parts/CreateSettingsSchema/CreateS
 
 test('creates a schema from distributed settings contributions', () => {
   expect(
-    CreateSettingsSchema.createSettingsSchema([
+    CreateSettingsSchema.createSettingsSchema(
       [
-        {
-          description: 'The font family of the editor',
-          id: 'editor.fontFamily',
-          type: 2,
-          value: 'Fira Code',
-        },
-        {
-          description: 'The font size of the editor',
-          id: 'editor.fontSize',
-          maximum: 100,
-          minimum: 10,
-          type: 5,
-          value: 15,
-        },
-        {
-          description: 'Controls how lines should wrap',
-          id: 'editor.wordWrap',
-          options: [
-            { id: 'editor.on', label: 'On' },
-            { id: 'editor.off', label: 'Off' },
-          ],
-          type: 1,
-          value: 'off',
-        },
-        {
-          description: 'Controls editor rulers',
-          id: 'editor.rulers',
-          type: 4,
-          value: [],
-        },
+        [
+          {
+            description: 'The font family of the editor',
+            id: 'editor.fontFamily',
+            type: 2,
+            value: 'Fira Code',
+          },
+          {
+            description: 'The font size of the editor',
+            id: 'editor.fontSize',
+            maximum: 100,
+            minimum: 10,
+            type: 5,
+            value: 15,
+          },
+          {
+            description: 'Controls how lines should wrap',
+            id: 'editor.wordWrap',
+            options: [
+              { id: 'editor.on', label: 'On' },
+              { id: 'editor.off', label: 'Off' },
+            ],
+            type: 1,
+            value: 'off',
+          },
+          {
+            description: 'Controls editor rulers',
+            id: 'editor.rulers',
+            type: 4,
+            value: [],
+          },
+        ],
+        [
+          {
+            description: 'Configures excluded files',
+            id: 'files.exclude',
+            type: 4,
+            value: { '**/.git': true },
+          },
+        ],
       ],
-      [
-        {
-          description: 'Configures excluded files',
-          id: 'files.exclude',
-          type: 4,
-          value: { '**/.git': true },
+      {
+        'gptvoice.tools.terminal.enabled': {
+          default: false,
+          description:
+            'Allow Gpt Voice to execute Bash commands in the opened workspace.',
+          type: 'boolean',
         },
-      ],
-    ]),
+      },
+    ),
   ).toEqual({
     properties: {
       'editor.fontFamily': {
@@ -86,6 +96,12 @@ test('creates a schema from distributed settings contributions', () => {
         maximum: undefined,
         minimum: undefined,
         type: 'object',
+      },
+      'gptvoice.tools.terminal.enabled': {
+        default: false,
+        description:
+          'Allow Gpt Voice to execute Bash commands in the opened workspace.',
+        type: 'boolean',
       },
     },
     type: 'object',


### PR DESCRIPTION
## Summary

- query enabled extensions' contributed configuration definitions through @lvce-editor/api
- merge extension setting schemas with the built-in Settings JSON schema
- add a dedicated end-to-end extension fixture that verifies gptvoice.tools.terminal.enabled is suggested
- update @lvce-editor/api to 9.27.0

## Validation

- npm test
- npm run type-check
- npm run lint
- npm run build:extension
- npm run e2e:headless
- git diff --check