### PR TITLE
feature: warn about unknown settings

### DIFF
--- a/packages/e2e/extension/extension.json
+++ b/packages/e2e/extension/extension.json
@@ -5,6 +5,7 @@
   "activation": [
     "onLanguage:json",
     "onCompletion:json",
+    "onDiagnostic:json",
     "onTabCompletion:json",
     "onHover:json"
   ],
@@ -14,6 +15,12 @@
   "completionProviders": [
     {
       "id": "json.provideCompletions.json",
+      "languageId": "json"
+    }
+  ],
+  "diagnosticProviders": [
+    {
+      "id": "json.provideDiagnostics.json",
       "languageId": "json"
     }
   ],

--- a/packages/e2e/src/json.settings-diagnostics.js
+++ b/packages/e2e/src/json.settings-diagnostics.js
@@ -1,30 +1,53 @@
-export const skip = true
-
 export const name = 'json.settings-diagnostics'
 
 export const test = async ({
   FileSystem,
   Workspace,
   Main,
+  Editor,
+  Panel,
   Settings,
   Locator,
   expect,
 }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
+  const settingsText = `{
+  "gptvoice.tools.terminal.enabled": true,
+  "gptvoice.tools.terminal.enable": true
+}`
   await FileSystem.writeFile(
     `${tmpDir}/settings.json`,
-    `{
-  "editor.fontSize": "invalid"
-}`,
+    settingsText,
   )
   await Workspace.setPath(tmpDir)
   await Settings.update({ 'editor.diagnostics': true })
 
   // act
   await Main.openUri(`${tmpDir}/settings.json`)
+  await Editor.setText(settingsText)
 
   // assert
+  const expectedDiagnostics = [
+    {
+      columnIndex: 3,
+      endColumnIndex: 33,
+      endRowIndex: 2,
+      message: 'Unknown setting "gptvoice.tools.terminal.enable".',
+      rowIndex: 2,
+      source: 'json',
+      type: 'warning',
+    },
+  ]
+  await Editor.shouldHaveDiagnostics(expectedDiagnostics)
+
+  const diagnosticWarning = Locator('.DiagnosticWarning')
   const diagnosticError = Locator('.DiagnosticError')
-  await expect(diagnosticError).toBeVisible()
+  await expect(diagnosticWarning).toBeVisible()
+  await expect(diagnosticError).toHaveCount(0)
+
+  await Panel.open('Problems')
+  const problems = Locator('.Viewlet.Problems')
+  await expect(problems.locator('.ProblemsWarningIcon')).toBeVisible()
+  await expect(problems.locator('.ProblemsErrorIcon')).toHaveCount(0)
 }

--- a/packages/extension/extension.json
+++ b/packages/extension/extension.json
@@ -5,6 +5,7 @@
   "activation": [
     "onLanguage:json",
     "onCompletion:json",
+    "onDiagnostic:json",
     "onTabCompletion:json",
     "onHover:json"
   ],
@@ -15,6 +16,12 @@
   "completionProviders": [
     {
       "id": "json.provideCompletions.json",
+      "languageId": "json"
+    }
+  ],
+  "diagnosticProviders": [
+    {
+      "id": "json.provideDiagnostics.json",
       "languageId": "json"
     }
   ],

--- a/packages/extension/src/parts/DiagnosticProvider/DiagnosticProvider.ts
+++ b/packages/extension/src/parts/DiagnosticProvider/DiagnosticProvider.ts
@@ -1,0 +1,24 @@
+import type { Diagnostic } from '@lvce-editor/api'
+import * as GetSchema from '../GetSchema/GetSchema.ts'
+import * as GetSchemaUri from '../GetSchemaUri/GetSchemaUri.ts'
+import * as SettingsDiagnostics from '../SettingsDiagnostics/SettingsDiagnostics.ts'
+
+interface TextDocument {
+  readonly text: string
+  readonly uri: string
+}
+
+export const id = 'json.provideDiagnostics.json'
+
+export const languageId = 'json'
+
+export const provideDiagnostics = async (
+  textDocument: TextDocument,
+): Promise<readonly Diagnostic[]> => {
+  const schemaUri = await GetSchemaUri.getSchemaUri(textDocument.uri)
+  if (schemaUri !== GetSchemaUri.settingsSchemaUri) {
+    return []
+  }
+  const schema = await GetSchema.getSchema(textDocument.uri)
+  return SettingsDiagnostics.getSettingsDiagnostics(textDocument.text, schema)
+}

--- a/packages/extension/src/parts/LanguageFeatures/LanguageFeatures.ts
+++ b/packages/extension/src/parts/LanguageFeatures/LanguageFeatures.ts
@@ -1,14 +1,17 @@
 import {
   registerCompletionProvider,
+  registerDiagnosticProvider,
   registerHoverProvider,
   registerSelectionProvider,
 } from '@lvce-editor/api'
 import * as CompletionProvider from '../CompletionProvider/CompletionProvider.ts'
+import * as DiagnosticProvider from '../DiagnosticProvider/DiagnosticProvider.ts'
 import * as HoverProvider from '../HoverProvider/HoverProvider.ts'
 import * as SelectionProvider from '../SelectionProvider/SelectionProvider.ts'
 
 export const register = (): void => {
   registerSelectionProvider(SelectionProvider)
   registerCompletionProvider(CompletionProvider)
+  registerDiagnosticProvider(DiagnosticProvider)
   registerHoverProvider(HoverProvider)
 }

--- a/packages/extension/src/parts/SettingsDiagnostics/SettingsDiagnostics.ts
+++ b/packages/extension/src/parts/SettingsDiagnostics/SettingsDiagnostics.ts
@@ -1,0 +1,102 @@
+import type { Diagnostic } from '@lvce-editor/api'
+import type { AstNode } from '../AstNode/AstNode.ts'
+import type { JsonSchema } from '../JsonSchema/JsonSchema.ts'
+import * as Jsonc from '../Jsonc/Jsonc.ts'
+import * as TokenType from '../TokenType/TokenType.ts'
+
+const getSubtreeEnd = (
+  nodes: readonly AstNode[],
+  index: number,
+): number => {
+  const node = nodes[index]
+  if (!node) {
+    return nodes.length
+  }
+  let end = index + 1
+  let remaining = node.childCount
+  while (remaining > 0 && end < nodes.length) {
+    const child = nodes[end]
+    remaining += child.childCount - 1
+    end++
+  }
+  return end
+}
+
+const parsePropertyName = (
+  text: string,
+  node: AstNode,
+): string | undefined => {
+  try {
+    const value: unknown = JSON.parse(
+      text.slice(node.offset, node.offset + node.length),
+    )
+    return typeof value === 'string' ? value : undefined
+  } catch {
+    return undefined
+  }
+}
+
+const getPosition = (
+  text: string,
+  offset: number,
+): { readonly columnIndex: number; readonly rowIndex: number } => {
+  let columnIndex = 0
+  let rowIndex = 0
+  for (let i = 0; i < offset; i++) {
+    if (text.charCodeAt(i) === 10) {
+      columnIndex = 0
+      rowIndex++
+    } else {
+      columnIndex++
+    }
+  }
+  return { columnIndex, rowIndex }
+}
+
+const createUnknownSettingDiagnostic = (
+  text: string,
+  node: AstNode,
+  propertyName: string,
+): Diagnostic => {
+  const start = getPosition(text, node.offset + 1)
+  const end = getPosition(text, node.offset + node.length - 1)
+  return {
+    ...start,
+    endColumnIndex: end.columnIndex,
+    endRowIndex: end.rowIndex,
+    message: `Unknown setting ${JSON.stringify(propertyName)}.`,
+    source: 'json',
+    type: 'warning',
+  }
+}
+
+export const getSettingsDiagnostics = (
+  text: string,
+  schema: JsonSchema,
+): readonly Diagnostic[] => {
+  const properties = schema.properties || {}
+  const nodes = Jsonc.parse(text)
+  const root = nodes[0]
+  if (!root || root.type !== TokenType.Object) {
+    return []
+  }
+  const diagnostics: Diagnostic[] = []
+  let index = 1
+  for (let i = 0; i < root.childCount && index < nodes.length; i++) {
+    const property = nodes[index]
+    const key = nodes[index + 1]
+    if (
+      property?.type === TokenType.Property &&
+      key?.type === TokenType.String
+    ) {
+      const propertyName = parsePropertyName(text, key)
+      if (propertyName !== undefined && !Object.hasOwn(properties, propertyName)) {
+        diagnostics.push(
+          createUnknownSettingDiagnostic(text, key, propertyName),
+        )
+      }
+    }
+    index = getSubtreeEnd(nodes, index)
+  }
+  return diagnostics
+}

--- a/packages/extension/test/SettingsDiagnostics.test.ts
+++ b/packages/extension/test/SettingsDiagnostics.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '@jest/globals'
+import * as SettingsDiagnostics from '../src/parts/SettingsDiagnostics/SettingsDiagnostics.ts'
+
+const schema = {
+  properties: {
+    'editor.fontSize': { type: 'number' },
+    'files.exclude': { type: 'object' },
+    'gptvoice.tools.terminal.enabled': { type: 'boolean' },
+  },
+  type: 'object',
+}
+
+test('returns a warning for an unknown setting', () => {
+  const text = `{
+  "editor.fontSiz": 15
+}`
+  expect(SettingsDiagnostics.getSettingsDiagnostics(text, schema)).toEqual([
+    {
+      columnIndex: 3,
+      endColumnIndex: 17,
+      endRowIndex: 1,
+      message: 'Unknown setting "editor.fontSiz".',
+      rowIndex: 1,
+      source: 'json',
+      type: 'warning',
+    },
+  ])
+})
+
+test('accepts built-in and extension-contributed settings', () => {
+  const text = `{
+  "editor.fontSize": 15,
+  "gptvoice.tools.terminal.enabled": true
+}`
+  expect(SettingsDiagnostics.getSettingsDiagnostics(text, schema)).toEqual([])
+})
+
+test('only checks top-level setting names', () => {
+  const text = `{
+  "files.exclude": {
+    "**/.git": true
+  }
+}`
+  expect(SettingsDiagnostics.getSettingsDiagnostics(text, schema)).toEqual([])
+})
+
+test('ignores incomplete property names', () => {
+  expect(SettingsDiagnostics.getSettingsDiagnostics('{ "editor.', schema)).toEqual(
+    [],
+  )
+})


### PR DESCRIPTION
Adds warning diagnostics for unknown top-level keys in Settings JSON, using the merged built-in and extension-contributed settings schema. Includes unit coverage and a headless end-to-end warning squiggle and Problems view regression test.