### PR TITLE
feature: clarify settings diagnostic source

### DIFF
--- a/packages/e2e/src/json.settings-diagnostics.js
+++ b/packages/e2e/src/json.settings-diagnostics.js
@@ -35,7 +35,7 @@ export const test = async ({
       endRowIndex: 2,
       message: 'Unknown setting "gptvoice.tools.terminal.enable".',
       rowIndex: 2,
-      source: 'json',
+      source: 'json (settings_validation)',
       type: 'warning',
     },
   ]

--- a/packages/extension/src/parts/SettingsDiagnostics/SettingsDiagnostics.ts
+++ b/packages/extension/src/parts/SettingsDiagnostics/SettingsDiagnostics.ts
@@ -65,7 +65,7 @@ const createUnknownSettingDiagnostic = (
     endColumnIndex: end.columnIndex,
     endRowIndex: end.rowIndex,
     message: `Unknown setting ${JSON.stringify(propertyName)}.`,
-    source: 'json',
+    source: 'json (settings_validation)',
     type: 'warning',
   }
 }

--- a/packages/extension/test/SettingsDiagnostics.test.ts
+++ b/packages/extension/test/SettingsDiagnostics.test.ts
@@ -21,7 +21,7 @@ test('returns a warning for an unknown setting', () => {
       endRowIndex: 1,
       message: 'Unknown setting "editor.fontSiz".',
       rowIndex: 1,
-      source: 'json',
+      source: 'json (settings_validation)',
       type: 'warning',
     },
   ])


### PR DESCRIPTION
Updates settings-validation warnings to use the more descriptive source label `json (settings_validation)`. Updates unit and end-to-end expectations for the new label.